### PR TITLE
Allow empty input ascii files

### DIFF
--- a/input_data.F90
+++ b/input_data.F90
@@ -984,7 +984,7 @@ subroutine read_varlist(localpet, file,nfields,field_names,field_names_target)
    enddo
    
    if (localpet==0) print*, "READING ", nfields, " FIELDS ACCORDING TO ", trim(file)
-   if ( nfields == 0) call error_handler("VARLIST FILE IS EMPTY.", -1)
+  !if ( nfields == 0) call error_handler("VARLIST FILE IS EMPTY.", -1) ! ok if there are no fields...
 
    allocate(field_names(nfields))
    allocate(field_names_target(nfields))

--- a/interp.F90
+++ b/interp.F90
@@ -178,6 +178,7 @@
     isrctermprocessing = 1
     
     !if (.not. interp_diag) then
+    if (n_hist_fields_2d_patch > 0) then
         method = ESMF_REGRIDMETHOD_BILINEAR
         if (localpet==0) print*,"- CREATE HIST BUNDLE PATCH REGRID ROUTEHANDLE"
     
@@ -191,6 +192,7 @@
          if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
             call error_handler("IN FieldBundleRegridStore", rc)
     !endif
+     endif
      
      if (localpet==0) print*,"- PATCH REGRID INIT FIELDS "                                
      call ESMF_FieldBundleRegrid(input_hist_bundle_2d_patch, target_hist_bundle_2d_patch, rh_patch, rc=rc)
@@ -213,6 +215,7 @@
      if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__))&
         call error_handler("IN FieldBundleRegrid", rc)
 
+    if (n_hist_fields_3d_nz>0) then
      call ESMF_FieldBundleRegridStore(input_hist_bundle_3d_nz, target_hist_bundle_3d_nz, &
                                          regridmethod=method, &
                                          routehandle=rh_patch, &
@@ -226,6 +229,7 @@
      call ESMF_FieldBundleRegrid(input_hist_bundle_3d_nz, target_hist_bundle_3d_nz, rh_patch, rc=rc)
      if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
         call error_handler("IN FieldBundleRegrid", rc)
+    endif
    
     if (n_hist_fields_3d_nzp1>0) then
        if (localpet==0) print*,"- CREATE HIST BUNDLE PATCH REGRID ROUTEHANDLE"

--- a/interp.F90
+++ b/interp.F90
@@ -192,12 +192,12 @@
          if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
             call error_handler("IN FieldBundleRegridStore", rc)
     !endif
-     endif
      
-     if (localpet==0) print*,"- PATCH REGRID INIT FIELDS "                                
-     call ESMF_FieldBundleRegrid(input_hist_bundle_2d_patch, target_hist_bundle_2d_patch, rh_patch, rc=rc)
-     if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-        call error_handler("IN FieldBundleRegrid", rc)
+       if (localpet==0) print*,"- PATCH REGRID INIT FIELDS "                                
+       call ESMF_FieldBundleRegrid(input_hist_bundle_2d_patch, target_hist_bundle_2d_patch, rh_patch, rc=rc)
+       if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+          call error_handler("IN FieldBundleRegrid", rc)
+     endif
 
      if (localpet==0) print*,"- CREATE HGT PATCH REGRID ROUTEHANDLE"
 


### PR DESCRIPTION
The code basically assumes there are some 3d history fields and some 2d "patch"-interpolated fields.  That was getting in the way of my attempts to use MPASSIT given diag-only MPAS output, so I put in a few lines of code to allow empty input ascii files.  Tested and it seems to work.