### PR TITLE
Use consistent compiler/libraries on Jet as other MPAS-WoFS programs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 set -eux
 
 target=${1:-"NULL"}
-compiler=${compiler:-"gnu"}
+compiler=${compiler:-"intel"}
 echo $target, $compiler
 if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
     unset -f module
@@ -31,8 +31,8 @@ if [[ "$target" == "hera" || "$target" == "orion" || "$target" == "wcoss2" || "$
    CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
    #CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DENABLE_DOCS=ON -DBUILD_TESTING=ON"
 else
-   CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug"
-   #CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
+  #CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug"
+  CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
 fi
 
 rm -fr ./build

--- a/build.sh
+++ b/build.sh
@@ -2,48 +2,57 @@
 #
 # Author: Larissa Reames CIWRO/NOAA/NSSL/FRDD
 
-set -eux
+#set -eux
 
 target=${1:-"NULL"}
-compiler=${compiler:-"intel"}
-echo $target, $compiler
+compiler=${2:-"intel"}
+debug=${3:-"false"}
+
+# If target is not set
+if [[ "$target" == "NULL" ]]; then
+    source ./machine-setup.sh
+fi
+
+echo "target=$target, compiler=$compiler"
+
+# Check for platform/compiler configuration file
+if [[ ! -f modulefiles/build.$target && ! -f modulefiles/build.$target.$compiler.lua ]]; then
+    echo "Platform ${target} configuration file not found in ./modulefiles, neither build.$target nor build.$target.$compiler.lua"
+    exit 1
+fi
+
 if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
     unset -f module
-    set +x
+    echo "Use platform configuration file: build.$target"
     source ./modulefiles/build.$target > /dev/null
-    set -x
-elif [[ "$compiler" == "gnu" ]]; then
-    set +x
-    source ./machine-setup.sh
-    source ./modulefiles/build.${target}.${compiler} > /dev/null
-    set -x
 else
-    set +x
-    source ./machine-setup.sh
+    echo "Use platform configuration file: build.$target.$compiler.lua"
     module use ./modulefiles
     module load build.$target.$compiler.lua
     module list
-    set -x
 fi
 
-if [[ "$target" == "hera" || "$target" == "orion" || "$target" == "wcoss2" || "$target" == "hercules" ]]; then
-   #CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug"
-   CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
-   #CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DENABLE_DOCS=ON -DBUILD_TESTING=ON"
+CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
+if [[ "$compiler" == "intel" ]]; then
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_Fortran_COMPILER=ifort"
+elif [[ "$compiler" == "gnu" ]]; then
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran"
+fi
+
+if [[ "${debug}" == "true" ]]; then
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Debug"
 else
-  #CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug"
-  CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=../ -DEMC_EXEC_DIR=ON -DBUILD_TESTING=OFF"
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_BUILD_TYPE=Release"
 fi
 
+# for a clean build folder
 rm -fr ./build
-mkdir ./build && cd ./build
+mkdir ./build && cd ./build || exit 0
 
+# do the building
 cmake .. ${CMAKE_FLAGS}
 
 make -j 8 VERBOSE=1
 make install
 
-#make test
-#ctest -I 4,5
-
-exit
+exit 0

--- a/build.sh
+++ b/build.sh
@@ -16,12 +16,15 @@ fi
 echo "target=$target, compiler=$compiler"
 
 # Check for platform/compiler configuration file
-if [[ ! -f modulefiles/build.$target && ! -f modulefiles/build.$target.$compiler.lua ]]; then
+if [[ ! -f modulefiles/build.$target && ! -f modulefiles/build.$target.$compiler.lua && ! -f modulefiles/build.$target.$compiler ]]; then
     echo "Platform ${target} configuration file not found in ./modulefiles, neither build.$target nor build.$target.$compiler.lua"
     exit 1
 fi
 
-if [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
+if [[ "$target" == "vecna" || "$compiler" == "gnu" ]]; then
+    echo "Use platform configuration file: build.$target.$compiler"
+    source ./modulefiles/build.$target.$compiler > /dev/null
+elif [[ "$target" == "linux.*" || "$target" == "macosx.*" ]]; then
     unset -f module
     echo "Use platform configuration file: build.$target"
     source ./modulefiles/build.$target > /dev/null

--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to compile UFS_UTILS on Jet
 ]])
 
-cmake_ver=os.getenv("cmake_ver") or "3.16.1"
+cmake_ver=os.getenv("cmake_ver") or "3.28.1"
 load(pathJoin("cmake", cmake_ver))
 
 hpss_ver=os.getenv("hpss_ver") or ""

--- a/modulefiles/build.jet.intel.lua
+++ b/modulefiles/build.jet.intel.lua
@@ -1,67 +1,34 @@
 help([[
-Load environment to compile UFS_UTILS on Jet
+Load environment to compile MPASSIT for MPAS-WoFS on Jet
 ]])
+
+whatis("Description: MPASSIT build environment")
 
 cmake_ver=os.getenv("cmake_ver") or "3.28.1"
 load(pathJoin("cmake", cmake_ver))
 
-hpss_ver=os.getenv("hpss_ver") or ""
-load(pathJoin("hpss", hpss_ver))
+load(pathJoin("gnu","9.2.0"))
 
-prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack")
+load(pathJoin("intel","2023.2.0"))
+load(pathJoin("impi","2023.2.0"))
 
-hpc_ver=os.getenv("hpc_ver") or "1.2.0"
-load(pathJoin("hpc", hpc_ver))
+load(pathJoin("pnetcdf","1.12.3"))
+load("szip")
+load(pathJoin("hdf5parallel","1.10.5"))
+load(pathJoin("netcdf-hdf5parallel","4.7.0"))
 
-hpc_intel_ver=os.getenv("hpc_intel_ver") or "2022.1.2"
-load(pathJoin("hpc-intel", hpc_intel_ver))
+setenv("PNETCDF","/apps/pnetcdf/1.12.3/intel_2023.2.0-impi")
 
-impi_ver=os.getenv("impi_ver") or "2022.1.2"
-load(pathJoin("hpc-impi", impi_ver))
+prepend_path("LD_LIBRARY_PATH", "/lfs4/NAGAPE/wof/miniconda3_RL/lib")   -- contains the grib2 libraries that are needed for the WPS compile
+prepend_path("CPATH",           "/usr/include/tirpc")                   -- only be important to the WRF build
 
-hdf5_ver=os.getenv("hdf5_ver") or "1.10.6"
-load(pathJoin("hdf5", hdf5_ver))
+-- # the Jasper environment settings for WPS
+setenv("JASPERLIB", "/lfs4/NAGAPE/wof/miniconda3_RL/lib")
+setenv("JASPERINC", "/lfs4/NAGAPE/wof/miniconda3_RL/lib/include/jasper")
 
-netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-load(pathJoin("netcdf", netcdf_ver))
+-- # ESMF V8.6 for MPASSIT
+setenv("ESMFMKFILE", "/lfs4/NAGAPE/hpc-wof1/ywang/tools/esmf-8.6.0/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk")
 
-netcdf_ver=os.getenv("pnetcdf_ver") or "1.11.2"
-load(pathJoin("pnetcdf", netcdf_ver))
-
-nccmp_ver=os.getenv("nccmp_ver") or "1.8.9.0"
-load(pathJoin("nccmp", nccmp_ver))
-
-esmf_ver=os.getenv("esmf_ver") or "8.4.0b08"
-load(pathJoin("esmf", esmf_ver))
-
-w3nco_ver=os.getenv("w3nco_ver") or "2.4.1"
-load(pathJoin("w3nco", w3nco_ver))
-
-sp_ver=os.getenv("sp_ver") or "2.3.3"
-load(pathJoin("sp", sp_ver))
-
-ip_ver=os.getenv("ip_ver") or "3.3.3"
-load(pathJoin("ip", ip_ver))
-
-bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-load(pathJoin("bacio", bacio_ver))
-
-sigio_ver=os.getenv("sigio_ver") or "2.3.2"
-load(pathJoin("sigio", sigio_ver))
-
-sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
-load(pathJoin("sfcio", sfcio_ver))
-
-nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
-load(pathJoin("nemsio", nemsio_ver))
-
-g2_ver=os.getenv("g2_ver") or "3.4.5"
-load(pathJoin("g2", g2_ver))
-
-prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
-load(pathJoin("prod_util", prod_util_ver))
-
-nco_ver=os.getenv("nco_ver") or "4.9.3"
-load(pathJoin("nco", nco_ver))
-
-whatis("Description: UFS_UTILS build environment")
+setenv("CMAKE_C_COMPILER", "mpiicc")
+setenv("CMAKE_CXX_COMPILER", "mpiicpc")
+setenv("CMAKE_Fortran_COMPILER", "mpiifort")


### PR DESCRIPTION
Modified files,

- _build.sh_ reorganized with three possible command line arguments, `TARGET COMPILER DEBUG`. Possible values are
   - `NULL intel true`           # Determine the target platform automatically, use `intel` compiler and turn on `debug` build
   - `NULL gnu `                  # Determine the target platform automatically, use `gnu` compiler and do NOT turn on `debug`
   - `jet intel`                        # Use `intel` compiler to build on Jet for a `release` build
   - _empty_                         # Determine the target platform automatically, use `intel` compiler and do NOT turn on `debug`
- _interp.F90_     Just deleted extra blank spaces
- _modulefiles/build.jet.intel.lua_     updated for Rocky Linux OS 8 on Jet

