### PR TITLE
Make NetCDF write parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Compiling instructions:
   (if your machine supports lua modulefiles) or build.[target]. In this file you will need to load 
   your desired compiling environment, including cmake and MPI. Environmental variables NETCDF and 
   ESMFMKFILE are also necessary and should be pointed to the top directory of the NETCDF install and
-  the file esmf.mk of your ESMF install, respectively.  
+  the file esmf.mk of your ESMF install, respectively. Note that this code requires NetCDF compiled
+  with hdf5. 
 
   An example file that loads the build environment through modulefiles and the extra libraries
   via LD_LIBRARY_PATH modification is provided in modulfiles/build.jet.test.intel.lua.

--- a/write_data.F90
+++ b/write_data.F90
@@ -123,7 +123,7 @@ contains
 
         type(esmf_field), allocatable    :: fields(:), field_write_2d(:), field_extra3(:)
         type(timedelta)                 :: xtime_dt
-        integer :: clb(2), cub(2)
+        integer :: clb(2), cub(2), clbu(2), cubu(2), clbv(2), cubv(2)
         real :: start,finish
         real(esmf_kind_r8), pointer :: dumptr_3d(:,:,:)
  
@@ -1042,136 +1042,169 @@ contains
 
 !  longitude
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LONGITUDE"
-        call ESMF_FieldGather(longitude_target_grid, dum2d, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LONGITUDE"
+        call ESMF_FieldGet(longitude_target_grid, farrayPtr=dum2dptr, computationalLBound=clb,&
+                             computationalUBound = cub, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
+            call error_handler("IN FieldGet", error)
+		
+		dum2d(:,:) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+		count1 = cub(1)-clb(1)+1
+		count2 = cub(2)-clb(2)+1		
         !if (localpet == 0) then
-            dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_lon, dum2dt, count=(/i_target, j_target, 1/))
+            !dum2dt(:, :, 1) = dum2d
+            error = nf90_put_var(ncid, id_lon, dum2d, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
             call netcdf_err(error, 'WRITING LONGITUDE RECORD')
         !end if
 
 !  latitude
 
-        !if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE"
-        call ESMF_FieldGather(latitude_target_grid, dum2d, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LATITUDE"
+        call ESMF_FieldGet(latitude_target_grid, farrayPtr=dum2dptr, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
+            call error_handler("IN FieldGet", error)
+		
+		dum2d(:,:) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
         !if (localpet == 0) then
             dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_lat, dum2dt, count=(/i_target, j_target, 1/))
+            error = nf90_put_var(ncid, id_lat, dum2d, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
             call netcdf_err(error, 'WRITING LATITUDE RECORD')
         !end if
 
+
 !  longitude on u grid
-        !if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LONGITUDE U"
-        call ESMF_FieldGather(longitude_u_target_grid, dum2du, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGetFOR TARGET GRID LONGITUDE U"
+        call ESMF_FieldGet(longitude_u_target_grid, dum2ptr, rootPet=0,  computationalLBound=clbu,&
+                             computationalUBound = cubu, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
+            call error_handler("IN FieldGet", error)
+            
+		dum2du = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+		count1u = cubu(1)-clbu(1)+1
+		count2u = cubu(2)-clbu(2)+1
         !if (localpet == 0) then
             dum2dtu(:,:,1) = dum2du
-            error = nf90_put_var(ncid, id_lonu, dum2dtu, count=(/i_target+1, j_target, 1/))
+            error = nf90_put_var(ncid, id_lonu, dum2du, start = (/clbu(1),clbu(2),1/),  &
+                                   count=(/count1u, count2u, 1/)))
             call netcdf_err(error, 'WRITING XLONG_U RECORD')
         !end if
 
 !  latitude on u grid
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE U"
-        call ESMF_FieldGather(latitude_u_target_grid, dum2du, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LATITUDE U"
+        call ESMF_FieldGet(latitude_u_target_grid, dum2dptr, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
+            call error_handler("IN FieldGet", error)
+            
+        dum2du = dum2dptr(clbu(1):cubu(1),clbu(2):cubu(2))
         !if (localpet == 0) then
-            dum2dtu(:,:,1) = dum2du
-            error = nf90_put_var(ncid, id_latu, dum2dtu, count=(/i_target+1, j_target, 1/))
+            error = nf90_put_var(ncid, id_latu, dum2du, start = (/clbu(1),clbu(2),1/),  &
+                                   count=(/count1u, count2u, 1/)))
             call netcdf_err(error, 'WRITING XLAT_U RECORD')
         !end if
 
 !  latitude on v grid
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE V"
-        call ESMF_FieldGather(latitude_v_target_grid, dum2dv(:, :), rootPet=0, rc=error)
+		if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LATITUDE V"
+        call ESMF_FieldGet(latitude_v_target_grid, dum2dptr, rootPet=0,  computationalLBound=clbv,&
+                             computationalUBound = cubv, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
+            call error_handler("IN FieldGet", error)
+            
+		count1v = cubv(1)-clbv(1)+1
+		count2v = cubv(2)-clbv(2)+1
+            
+        dum2dv = dum2dptr(clbv(1):cubv(1),clbv(2):cubv(2))
         !if (localpet == 0) then
-            dum2dtv(:,:,1) = dum2dv
-            error = nf90_put_var(ncid, id_latv, dum2dtv, count=(/i_target, j_target+1, 1/))
-            call netcdf_err(error, 'WRITING XLAT_V RECORD')
+            error = nf90_put_var(ncid, id_latv, dum2dv, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1v, count2v, 1/)))
+            call netcdf_err(error, 'WRITING XLAT_U RECORD')
         !end if
 
 !  longitude on v grid
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LONGITUDE V"
-        call ESMF_FieldGather(longitude_v_target_grid, dum2dv, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LONGITUDE V"
+        call ESMF_FieldGet(longitude_v_target_grid, dum2dptr, rootPet=0,  computationalLBound=clb,&
+                             computationalUBound = cub, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
+            call error_handler("IN FieldGet", error)
+            
+
+        dum2dv = dum2dptr(clbv(1):cubv(1),clbv(2):cubv(2))
         !if (localpet == 0) then
-            dum2dtv(:,:,1) = dum2dv
-            error = nf90_put_var(ncid, id_lonv, dum2dtv, count=(/i_target, j_target+1, 1/))
-            call netcdf_err(error, 'WRITING XLONG_V RECORD')
+            error = nf90_put_var(ncid, id_lonv, dum2dv, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1v, count2v, 1/)))
+            call netcdf_err(error, 'WRITING XLAT_U RECORD')
         !end if
 
 ! mapfac on mass grid
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID mapfac_m"
-        call ESMF_FieldGather(mapfac_m_target_grid, dum2d, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID mapfac_m"
+        call ESMF_FieldGet(mapfac_m_target_grid, dum2dptr, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
+            call error_handler("IN FieldGet", error)
+            
+		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
         !if (localpet == 0) then
-            dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_mfm, dum2dt, count=(/i_target, j_target, 1/))
+            error = nf90_put_var(ncid, id_mfm, dum2d, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
             call netcdf_err(error, 'WRITING MAPFAC_M RECORD')
         !end if
 
 ! mapfac on u grid
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID mapfac_u"
-        call ESMF_FieldGather(mapfac_u_target_grid, dum2du, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID mapfac_u"
+        call ESMF_FieldGet(mapfac_u_target_grid,dum2dptr, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
-        if (localpet == 0) then
-            dum2dtu(:, :, 1) = dum2du
-            error = nf90_put_var(ncid, id_mfu, dum2dtu, count=shape(dum2dtu))
+            call error_handler("IN FieldGet", error)
+            
+        dum2du = dum2dptr(clbu(1):cubu(1),clbu(2):cubu(2))
+        !if (localpet == 0) then
+            error = nf90_put_var(ncid, id_mfu, dum2du, start = (/clbu(1),clbu(2),1/),  &
+                                   count=(/count1u, count2u, 1/)))
             call netcdf_err(error, 'WRITING MAPFAC_U RECORD')
         end if
 
 !mapfac on v grid
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID mapfac_v"
-        call ESMF_FieldGather(mapfac_v_target_grid, dum2dv, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID mapfac_v"
+        call ESMF_FieldGet(mapfac_v_target_grid, dum2dptr, rootPet=0,  computationalLBound=clb,&
+                             computationalUBound = cub, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
+            call error_handler("IN FieldGet", error)
+            
 
-        if (localpet == 0) then
-            dum2dtv(:, :, 1) = dum2dv
-            error = nf90_put_var(ncid, id_mfv, dum2dtv, count=shape(dum2dtv))
+        dum2dv = dum2dptr(clbv(1):cubv(1),clbv(2):cubv(2))
+        !if (localpet == 0) then
+            error = nf90_put_var(ncid, id_lmfv, dum2du, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1v, count2v, 1/)))
             call netcdf_err(error, 'WRITING MAPFAC_V RECORD')
         end if
 
         if (PROJ_CODE==PROJ_LC) then
 !sinalpha
         if (localpet == 0) print*, "- CALL FieldGather FOR TARGET GRID sinalpha"
-        call ESMF_FieldGather(sina_target_grid, dum2d, rootPet=0, rc=error)
+        call ESMF_FieldGather(sina_target_grid, dum2dptr, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
-        if (localpet == 0) then
-            dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_sina, dum2dt, count=shape(dum2dt))
+            call error_handler("IN FieldGet", error)
+            
+		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+        !if (localpet == 0) then
+            error = nf90_put_var(ncid, id_sina dum2d, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
             call netcdf_err(error, 'WRITING SINALPHA RECORD')
         end if
 
 !cosalpha
         if (localpet == 0) print*, "- CALL FieldGather FOR TARGET GRID cosalpha"
-        call ESMF_FieldGather(cosa_target_grid, dum2d, rootPet=0, rc=error)
+        call ESMF_FieldGather(cosa_target_grid, dum2dptr, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
-        if (localpet == 0) then
-            dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_cosa, dum2dt, count=shape(dum2dt))
+            call error_handler("IN FieldGet", error)
+            
+		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+        !if (localpet == 0) then
+            error = nf90_put_var(ncid, id_cosa, dum2d, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
             call netcdf_err(error, 'WRITING COSALPHA RECORD')
         end if
         endif
@@ -1185,67 +1218,55 @@ contains
 
 !  hgt
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE"
-        call ESMF_FieldGather(hgt_target_grid, dum2d, rootPet=0, rc=error)
+        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID HGT"
+        call ESMF_FieldGet(hgt_target_grid, dum2dptr, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGather", error)
-
-        if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID HGT"
-        if (localpet == 0) then
-            dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_hgt, dum2dt, count=(/i_target, j_target, 1/))
+            call error_handler("IN FieldGet", error)
+            
+		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+		if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID HGT"
+        !if (localpet == 0) then
+            error = nf90_put_var(ncid, id_hgt dum2d, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
             call netcdf_err(error, 'WRITING HGT RECORD')
         end if
 !   u
        if (do_u_interp == 1) then
           if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID U"
-          if (localpet == 0) then 
-            allocate (dum3dtmp(i_target + 1, j_target, nz_input))
-          else
-            allocate (dum3dtmp(0,0,0))
-          endif
-          call ESMF_FieldGather(u_target_grid, dum3dtmp, rootPet=0, rc=error)
+
+          allocate (dum3dtmp(count1u, count2u, nz_input))
+
+          call ESMF_FieldGet(u_target_grid, dum3dptr, rootPet=0, rc=error)
           if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-             call error_handler("IN FieldGather", error)
+             call error_handler("IN FieldGet", error)
 
           if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID U"
-          if (localpet == 0) then
-              call cpu_time(start)
-              error = nf90_put_var(ncid, id_u, dum3dtmp, count=(/i_target + 1, j_target, nz_input, 1/))
+		  dum3dtmp(:,:,:) = dum3dptr(clbu(1):cubu(1),clbu(2):cub(2),:)
+              error = nf90_put_var(ncid, id_u, dum3dtmp,  start = (/clbu(1),clbu(2),1,1/),  &
+                                   count=(/count1u, count2u, nz_input,1/)))
               call netcdf_err(error, 'WRITING U RECORD')
-              call cpu_time(finish)
-              print '("Time = ",f6.3," seconds.")',finish-start
-          end if
+
           deallocate(dum3dtmp)
        endif
 
 !   v
        if (do_v_interp == 1) then
           if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID V"
-          !if (localpet == 0) then
-          !  allocate (dum3dtmp(i_target, j_target + 1, nz_input))
-          !else
-          !  allocate (dum3dtmp(0,0,0))
-          !endif
-          !call ESMF_FieldGather(v_target_grid, dum3dtmp, rootPet=0, rc=error)
-          !if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-          !   call error_handler("IN FieldGather", error)
-          call ESMF_FieldGet(v_target_grid, farrayPtr=dumptr_3d, computationalLBound=clb,&
-                             computationalUBound = cub, rc=error)
+
+          allocate (dum3dtmp(count1v, count2v, nz_input))
+
+          call ESMF_FieldGet(v_target_grid, farrayPtr=dum3dptr, rc=error)
           if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
              call error_handler("IN FieldGet", error)
           dum3dtmp(:,:,:) = dumptr_3d(clb(1):cub(1),clb(2):cub(2),:)
-          allocate(dum3dtmp(cub(1)-clb(1)+1, cub(2)-clb(2)+1, nz_input))
+
           if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID V"
-          if (localpet == 0) call cpu_time(start)
-              ! set to use MPI/PnetCDF collective I/O
-              error =  nf90_var_par_access(ncid, id_v, NF90_COLLECTIVE)
-              call netcdf_err(error ,'SETTING PAR ACCESS ON V')
-              error = nf90_put_var(ncid, id_v, dum3dtmp, start = (/clb(1),clb(2),1,1/),  &
-                                   count=(/cub(1)-clb(1)+1, cub(2)-clb(2)+1, nz_input, 1/))
-              call netcdf_err(error, 'WRITING V RECORD')
-          if (localpet==0) call cpu_time(finish)
-          if (localpet==0) print '("Time = ",f6.3," seconds.")',finish-start
+		  ! set to use MPI/PnetCDF collective I/O
+		  error =  nf90_var_par_access(ncid, id_v, NF90_COLLECTIVE)
+		  call netcdf_err(error ,'SETTING PAR ACCESS ON V')
+		  error = nf90_put_var(ncid, id_v, dum3dtmp, start = (/clbv(1),clbv(2),1,1/),  &
+							   count=(/count1v, count2v, nz_input, 1/))
+		  call netcdf_err(error, 'WRITING V RECORD')
           deallocate(dum3dtmp)
        endif
 
@@ -1311,7 +1332,8 @@ contains
             if (localpet == 0) then
                 print *, "- WRITE TO FILE ", trim(varname)
                 dum2dt(:, :, 1) = dum2d
-                error = nf90_put_var(ncid, id_vars2(i), dum2dt, count=(/i_target, j_target, 1/))
+                error = nf90_put_var(ncid, id_vars2(i), dum2dt, start = (/clb(1),clb(2),1/),  &
+                                   count=(/count1, count2, 1/)))
                 call netcdf_err(error, 'WRITING RECORD')
             end if
         end do

--- a/write_data.F90
+++ b/write_data.F90
@@ -1540,12 +1540,12 @@ contains
             allocate(dum3d(count1, count2, nz_input))
             dum3d(:,:,:) = 0.0
             !print *, trim(varname), minval(dum3d), maxval(dum3d)
-            
             error = nf90_put_var(ncid, id_dummy3d_p, dum3d, start = (/clb(1),clb(2),1,1/), & 
                                 count=(/count1, count2, nz_input, 1/))
             call netcdf_err(error, 'WRITING RECORD')
         end if
 
+        if (localpet==0) print*, "deallocating everything"
         deallocate(dum3d, dum1d)
         if (allocated(target_hist_longname_2d_cons)) deallocate (target_hist_longname_2d_cons)
         if (allocated(target_hist_longname_2d_nstd)) deallocate (target_hist_longname_2d_nstd)
@@ -1562,7 +1562,9 @@ contains
         if (allocated(target_hist_units_3d_vert)) deallocate (target_hist_units_3d_vert)
         if (allocated(target_diag_units)) deallocate (target_diag_units)
 
-        if (localpet == 0) error = nf90_close(ncid)
+        
+        error = nf90_close(ncid)
+        call netcdf_err(error, 'CLOSING FILE')
 
     end subroutine write_to_file
 

--- a/write_data.F90
+++ b/write_data.F90
@@ -123,8 +123,8 @@ contains
 
         type(esmf_field), allocatable    :: fields(:), field_write_2d(:), field_extra3(:)
         type(timedelta)                 :: xtime_dt
-        integer :: clb(2), cub(2), clbu(2), cubu(2), clbv(2), cubv(2)
-        integer :: count1, count2, count1u, count2u, count1v, count2v
+        integer :: clb(2), cub(2), clbu(2), cubu(2), clbv(2), cubv(2), clbvert(2), cubvert(2)
+        integer :: count1, count2, count1u, count2u, count1v, count2v , count1vert, count2vert
         real :: start,finish
         real(esmf_kind_r8), pointer :: dum2dptr(:,:), dum3dptr(:,:,:)
  
@@ -136,46 +136,15 @@ contains
         allocate (id_vars3_vert(n_hist_fields_3d_vert))
         allocate (id_vars_soil(n_hist_fields_soil))
 
-        if (localpet == 0) then
-            allocate (dumsmall(nsoil_input, 1))
-            !allocate (dum2d(i_target, j_target))
-            !allocate (dum2dt(i_target, j_target, 1))
-            call ESMF_GridGet(target_grid, 1, ESMF_STAGGERLOC_EDGE1, maxIndex=maxinds, minIndex=mininds, rc=error)
-            !allocate (dum2du(maxinds(1) - mininds(1) + 1, maxinds(2) - mininds(2) + 1))
-            !allocate (dum2dtu(maxinds(1) - mininds(1) + 1, maxinds(2) - mininds(2) + 1, 1))
-            !call ESMF_GridGet(target_grid, 1, ESMF_STAGGERLOC_EDGE2, maxIndex=maxinds, minIndex=mininds, rc=error)
-            !allocate (dum2dv(maxinds(1) - mininds(1) + 1, maxinds(2) - mininds(2) + 1))
-            !allocate (dum2dtv(maxinds(1) - mininds(1) + 1, maxinds(2) - mininds(2) + 1, 1))
-            !allocate (dum3d(i_target, j_target, nz_input))
-            !allocate (dum3dt(i_target, j_target, nz_input, 1))
-            allocate (dum3dp1(i_target, j_target, nzp1_input))
-            allocate (dum3dp1t(i_target, j_target, nzp1_input, 1))
-            allocate (dumsoil(i_target, j_target, nsoil_input))
-            allocate (dumsoilt(i_target, j_target, nsoil_input, 1))
-            allocate (dum1d(1))
-        else
-            !allocate (dumsmall(0, 0))
-            !allocate (dum2d(0, 0))
-            !allocate (dum2dt(0, 0, 0))
-            !allocate (dum2du(0, 0))
-            !allocate (dum2dtu(0, 0, 0))
-            !allocate (dum2dv(0, 0))
-            !allocate (dum2dtv(0, 0, 0))
-            !allocate (dum3d(0, 0, 0))
-            allocate (dum3dt(0, 0, 0, 0))
-            allocate (dum3dp1(0, 0, 0))
-            allocate (dum3dp1t(0, 0, 0, 0))
-            allocate (dumsoil(0, 0, 0))
-            allocate (dumsoilt(0, 0, 0, 0))
-            allocate (dum1d(0))
-        end if
-
-       ! if (localpet == 0) then
+        allocate (dumsmall(nsoil_input, 1))
+        allocate (dum3d(i_target, j_target, nz_input))
+        allocate (dum1d(1))
 
 !--- open the file
-            error = nf90_create(output_file, NF90_NETCDF4, ncid, &
-                                comm = MPI_COMM_WORLD, &
-                                info = MPI_INFO_NULL)
+            error = nf90_create_par(output_file, NF90_NETCDF4, &
+                                MPI_COMM_WORLD, &
+                                MPI_INFO_NULL, &
+                                ncid)
             call netcdf_err(error, 'CREATING FILE '//trim(output_file))
        !if (localpet==0 ) then
 !--- define dimension
@@ -329,7 +298,7 @@ contains
             error = nf90_put_att(ncid, id_lon, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
             error =  nf90_var_par_access(ncid, id_lon, NF90_COLLECTIVE)
-            call netcdf_err(error ,'SETTING PAR ACCESS ON V')
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
         
             error = nf90_def_var(ncid, 'XLONG_U', NF90_FLOAT, (/dim_lon_stag, dim_lat, dim_time/), id_lonu)
             call netcdf_err(error, 'DEFINING GEOLON FIELD')
@@ -345,6 +314,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_lonu, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_lonu, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'XLONG_V', NF90_FLOAT, (/dim_lon, dim_lat_stag, dim_time/), id_lonv)
             call netcdf_err(error, 'DEFINING GEOLON FIELD')
@@ -360,6 +331,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_lonv, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_lonv, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'XLAT', NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_lat)
             call netcdf_err(error, 'DEFINING GEOLAT FIELD')
@@ -375,6 +348,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_lat, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_lat, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'XLAT_U', NF90_FLOAT, (/dim_lon_stag, dim_lat, dim_time/), id_latu)
             call netcdf_err(error, 'DEFINING GEOLAT FIELD')
@@ -390,6 +365,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_latu, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_latu, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'XLAT_V', NF90_FLOAT, (/dim_lon, dim_lat_stag, dim_time/), id_latv)
             call netcdf_err(error, 'DEFINING GEOLAT FIELD')
@@ -405,6 +382,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_latv, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_latv, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'MAPFAC_M', NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_mfm)
             call netcdf_err(error, 'DEFINING MAPFAC_M FIELD')
@@ -420,6 +399,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_mfm, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_mfm, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'MAPFAC_U', NF90_FLOAT, (/dim_lon_stag, dim_lat, dim_time/), id_mfu)
             call netcdf_err(error, 'DEFINING MAPFAC_U FIELD')
@@ -435,6 +416,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_mfu, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_mfu, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'MAPFAC_V', NF90_FLOAT, (/dim_lon, dim_lat_stag, dim_time/), id_mfv)
             call netcdf_err(error, 'DEFINING MAPFAC_V FIELD')
@@ -450,6 +433,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_mfv, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_mfv, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             if (PROJ_CODE==PROJ_LC) then
                error = nf90_def_var(ncid, 'SINALPHA', NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_sina)
@@ -466,17 +451,21 @@ contains
                call netcdf_err(error, 'DEFINING STAGGER')
                error = nf90_put_att(ncid, id_sina, "FieldType", 104)
                call netcdf_err(error, 'DEFINING FieldType')
+               error =  nf90_var_par_access(ncid, id_sina, NF90_COLLECTIVE)
+               call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
                error = nf90_def_var(ncid, 'COSALPHA', NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_cosa)
                call netcdf_err(error, 'DEFINING COAALPHA FIELD')
-               error = nf90_put_att(ncid, id_sina, "description", "COSINE OF GRID ROTATION ANGLE ALPHA")
+               error = nf90_put_att(ncid, id_cosa, "description", "COSINE OF GRID ROTATION ANGLE ALPHA")
             
-               error = nf90_put_att(ncid, id_sina, "coordinates", "XLONG XLAT")
+               error = nf90_put_att(ncid, id_cosa, "coordinates", "XLONG XLAT")
                call netcdf_err(error, 'DEFINING COORD')
-               error = nf90_put_att(ncid, id_sina, "stagger", " ")
+               error = nf90_put_att(ncid, id_cosa, "stagger", " ")
                call netcdf_err(error, 'DEFINING STAGGER')
-               error = nf90_put_att(ncid, id_sina, "FieldType", 104)
-               call netcdf_err(error, 'DEFINING FieldType')     
+               error = nf90_put_att(ncid, id_cosa, "FieldType", 104)
+               call netcdf_err(error, 'DEFINING FieldType')
+               error =  nf90_var_par_access(ncid, id_cosa, NF90_COLLECTIVE)
+               call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')     
             endif
 
             error = nf90_def_var(ncid, 'Z_C', NF90_FLOAT, (/dim_lon, dim_lat, dim_zp1, dim_time/), id_z)
@@ -493,6 +482,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_z, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_z, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'ZS', NF90_FLOAT, (/dim_soil, dim_time/), id_zs)
             call netcdf_err(error, 'DEFINING ZS FIELD')
@@ -508,6 +499,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_zs, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_zs, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'HGT', NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_hgt)
             call netcdf_err(error, 'DEFINING HGT FIELD')
@@ -525,6 +518,8 @@ contains
             call netcdf_err(error, 'DEFINING FieldType')
             error = nf90_put_att(ncid, id_hgt, "_FillValue", missing_value)
             call netcdf_err(error, 'DEFINING _FillValue')
+            error =  nf90_var_par_access(ncid, id_hgt, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'Times', NF90_CHAR, (/dim_str, dim_time/), id_times)
             call netcdf_err(error, 'DEFINING Times FIELD')
@@ -538,6 +533,8 @@ contains
             call netcdf_err(error, 'DEFINING STAGGER')
             error = nf90_put_att(ncid, id_times, "FieldType", 104)
             call netcdf_err(error, 'DEFINING FieldType')
+            error =  nf90_var_par_access(ncid, id_times, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'ITIMESTEP', NF90_INT, (/dim_time/), id_itime)
             call netcdf_err(error, 'DEFINING ITIMESTEP FIELD')
@@ -551,6 +548,8 @@ contains
             call netcdf_err(error, 'DEFINING FieldType')
             error = nf90_put_att(ncid, id_itime, "MemoryOrder", "O ")
             call netcdf_err(error, 'DEFINING MemoryOrder')
+            error =  nf90_var_par_access(ncid, id_itime, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             error = nf90_def_var(ncid, 'XTIME', NF90_FLOAT, (/dim_time/), id_xtime)
             call netcdf_err(error, 'DEFINING XTIME FIELD')
@@ -564,6 +563,8 @@ contains
             call netcdf_err(error, 'DEFINING FieldType')
             error = nf90_put_att(ncid, id_xtime, "MemoryOrder", "O ")
             call netcdf_err(error, 'DEFINING MemoryOrder')
+            error =  nf90_var_par_access(ncid, id_xtime, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
         !end if
 
@@ -588,47 +589,47 @@ contains
                 if (ndims == 2) then
                     k = k + 1
                     field_write_2d(k) = fields(i)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE 2d diag ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
-                        call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
-                        call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars2(k), "coordinates", "XLONG XLAT XTIME")
-                        call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars2(k), "units", target_diag_units(i))
-                        call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars2(k), "description", target_diag_longname(i))
-                        call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars2(k), "stagger", "")
-                        call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars2(k), "FieldType", 104)
-                        call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
-                        call netcdf_err(error, 'DEFINING _FillValue')
-                    !end if
+                     if (localpet == 0) print *, "- DEFINE 2d diag ON FILE TARGET GRID ", varname
+                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
+                     call netcdf_err(error, 'DEFINING VAR')
+                     error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
+                     call netcdf_err(error, 'DEFINING MEMORYORDER')
+                     error = nf90_put_att(ncid, id_vars2(k), "coordinates", "XLONG XLAT XTIME")
+                     call netcdf_err(error, 'DEFINING COORD')
+                     error = nf90_put_att(ncid, id_vars2(k), "units", target_diag_units(i))
+                     call netcdf_err(error, 'DEFINING UNITS')
+                     error = nf90_put_att(ncid, id_vars2(k), "description", target_diag_longname(i))
+                     call netcdf_err(error, 'DEFINING LONG_NAME')
+                     error = nf90_put_att(ncid, id_vars2(k), "stagger", "")
+                     call netcdf_err(error, 'DEFINING STAGGER')
+                     error = nf90_put_att(ncid, id_vars2(k), "FieldType", 104)
+                     call netcdf_err(error, 'DEFINING FieldType')
+                     error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
+                     call netcdf_err(error, 'DEFINING _FillValue')
+                     error =  nf90_var_par_access(ncid, id_vars2(k), NF90_COLLECTIVE)
+                     call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                 else
                     m = m + 1
                     field_extra3(m) = fields(i)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE 3d diag ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(m))
-                        call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "MemoryOrder", "XYZ ")
-                        call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "coordinates", "XLONG XLAT XTIME")
-                        call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "units", target_diag_units(i))
-                        call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "description", target_diag_longname(i))
-                        call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "stagger", "")
-                        call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "FieldType", 104)
-                        call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars3_nz(m), "_FillValue", missing_value)
-                        call netcdf_err(error, 'DEFINING _FillValue')
-                    !end if
+                     if (localpet == 0) print *, "- DEFINE 3d diag ON FILE TARGET GRID ", varname
+                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(m))
+                     call netcdf_err(error, 'DEFINING VAR')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "MemoryOrder", "XYZ ")
+                     call netcdf_err(error, 'DEFINING MEMORYORDER')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "coordinates", "XLONG XLAT XTIME")
+                     call netcdf_err(error, 'DEFINING COORD')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "units", target_diag_units(i))
+                     call netcdf_err(error, 'DEFINING UNITS')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "description", target_diag_longname(i))
+                     call netcdf_err(error, 'DEFINING LONG_NAME')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "stagger", "")
+                     call netcdf_err(error, 'DEFINING STAGGER')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "FieldType", 104)
+                     call netcdf_err(error, 'DEFINING FieldType')
+                     error = nf90_put_att(ncid, id_vars3_nz(m), "_FillValue", missing_value)
+                     call netcdf_err(error, 'DEFINING _FillValue')
+                     error =  nf90_var_par_access(ncid, id_vars3_nz(m), NF90_COLLECTIVE)
+                     call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                 end if
             end do
             deallocate (fields)
@@ -668,6 +669,8 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
+                        error =  nf90_var_par_access(ncid, id_vars2(k), NF90_COLLECTIVE)
+                        call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                     !end if
                 end do
                 deallocate (fields)
@@ -688,24 +691,24 @@ contains
 
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     field_write_2d(k) = fields(i)
-                    !if (localpet == 0) then
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
-                        call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
-                        call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars2(k), "coordinates", "XLONG XLAT XTIME")
-                        call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars2(k), "units", target_hist_units_2d_patch(i))
-                        call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars2(k), "description", target_hist_longname_2d_patch(i))
-                        call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars2(k), "stagger", "")
-                        call netcdf_err(error, 'DEFINING STAGGE')
-                        error = nf90_put_att(ncid, id_vars2(k), "FieldType", 104)
-                        call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
-                        call netcdf_err(error, 'DEFINING _FillValue')
-                    !end if
+                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
+                     call netcdf_err(error, 'DEFINING VAR')
+                     error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
+                     call netcdf_err(error, 'DEFINING MEMORYORDER')
+                     error = nf90_put_att(ncid, id_vars2(k), "coordinates", "XLONG XLAT XTIME")
+                     call netcdf_err(error, 'DEFINING COORD')
+                     error = nf90_put_att(ncid, id_vars2(k), "units", target_hist_units_2d_patch(i))
+                     call netcdf_err(error, 'DEFINING UNITS')
+                     error = nf90_put_att(ncid, id_vars2(k), "description", target_hist_longname_2d_patch(i))
+                     call netcdf_err(error, 'DEFINING LONG_NAME')
+                     error = nf90_put_att(ncid, id_vars2(k), "stagger", "")
+                     call netcdf_err(error, 'DEFINING STAGGE')
+                     error = nf90_put_att(ncid, id_vars2(k), "FieldType", 104)
+                     call netcdf_err(error, 'DEFINING FieldType')
+                     error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
+                     call netcdf_err(error, 'DEFINING _FillValue')
+                     error =  nf90_var_par_access(ncid, id_vars2(k), NF90_COLLECTIVE)
+                     call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                 end do
                 deallocate (fields)
             end if
@@ -723,25 +726,25 @@ contains
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
                     field_write_2d(k) = fields(i)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
-                        call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
-                        call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars2(k), "coordinates", "XLONG XLAT XTIME")
-                        call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars2(k), "units", target_hist_units_2d_nstd(i))
-                        call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars2(k), "description", target_hist_longname_2d_nstd(i))
-                        call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars2(k), "stagger", "")
-                        call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars2(k), "FieldType", 104)
-                        call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
-                        call netcdf_err(error, 'DEFINING _FillValue')
-                    !end if
+                    if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
+                    error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
+                    call netcdf_err(error, 'DEFINING VAR')
+                    error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
+                    call netcdf_err(error, 'DEFINING MEMORYORDER')
+                    error = nf90_put_att(ncid, id_vars2(k), "coordinates", "XLONG XLAT XTIME")
+                    call netcdf_err(error, 'DEFINING COORD')
+                    error = nf90_put_att(ncid, id_vars2(k), "units", target_hist_units_2d_nstd(i))
+                    call netcdf_err(error, 'DEFINING UNITS')
+                    error = nf90_put_att(ncid, id_vars2(k), "description", target_hist_longname_2d_nstd(i))
+                    call netcdf_err(error, 'DEFINING LONG_NAME')
+                    error = nf90_put_att(ncid, id_vars2(k), "stagger", "")
+                    call netcdf_err(error, 'DEFINING STAGGER')
+                    error = nf90_put_att(ncid, id_vars2(k), "FieldType", 104)
+                    call netcdf_err(error, 'DEFINING FieldType')
+                    error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
+                    call netcdf_err(error, 'DEFINING _FillValue')
+                    error =  nf90_var_par_access(ncid, id_vars2(k), NF90_COLLECTIVE)
+                    call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                 end do
                 deallocate (fields)
             end if
@@ -757,25 +760,25 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_soil, dim_time/), id_vars_soil(i))
-                        call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "MemoryOrder", "XYZ ")
-                        call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "coordinates", "XLONG XLAT XTIME")
-                        call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "units", target_hist_units_soil(i))
-                        call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "description", target_hist_longname_soil(i))
-                        call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "stagger", "")
-                        call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "FieldType", 104)
-                        call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars_soil(i), "_FillValue", missing_value)
-                        call netcdf_err(error, 'DEFINING _FillValue')
-                    !end if
+                    if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
+                    error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_soil, dim_time/), id_vars_soil(i))
+                    call netcdf_err(error, 'DEFINING VAR')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "MemoryOrder", "XYZ ")
+                    call netcdf_err(error, 'DEFINING MEMORYORDER')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "coordinates", "XLONG XLAT XTIME")
+                    call netcdf_err(error, 'DEFINING COORD')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "units", target_hist_units_soil(i))
+                    call netcdf_err(error, 'DEFINING UNITS')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "description", target_hist_longname_soil(i))
+                    call netcdf_err(error, 'DEFINING LONG_NAME')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "stagger", "")
+                    call netcdf_err(error, 'DEFINING STAGGER')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "FieldType", 104)
+                    call netcdf_err(error, 'DEFINING FieldType')
+                    error = nf90_put_att(ncid, id_vars_soil(i), "_FillValue", missing_value)
+                    call netcdf_err(error, 'DEFINING _FillValue')
+                    error =  nf90_var_par_access(ncid, id_vars_soil(i), NF90_COLLECTIVE)
+                    call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                 end do
                 deallocate (fields)
             end if
@@ -792,69 +795,72 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(i + n3d))
+                    if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
+                    error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(i + n3d))
+                    call netcdf_err(error, 'DEFINING VAR')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "MemoryOrder", "XYZ ")
+                    call netcdf_err(error, 'DEFINING MEMORYORDER')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "coordinates", "XLONG XLAT XTIME")
+                    call netcdf_err(error, 'DEFINING COORD')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "units", target_hist_units_3d_nz(i))
+                    call netcdf_err(error, 'DEFINING UNITS')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "description", target_hist_longname_3d_nz(i))
+                    call netcdf_err(error, 'DEFINING LONG_NAME')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "stagger", "")
+                    call netcdf_err(error, 'DEFINING STAGGER')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "FieldType", 104)
+                    call netcdf_err(error, 'DEFINING FieldType')
+                    error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "_FillValue", missing_value)
+                    call netcdf_err(error, 'DEFINING _FillValue')
+                    error =  nf90_var_par_access(ncid, id_vars3_nz(i + n3d), NF90_COLLECTIVE)
+                    call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
+
+                    if (wrf_mod_vars .and. trim(varname) == 'MUB') then
+                        if (localpet == 0) print *, "- DEFINE ON FILE STAGGERED TARGET GRID MU"
+                        error = nf90_def_var(ncid, 'MU', NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_mu)
                         call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "MemoryOrder", "XYZ ")
+                        error = nf90_put_att(ncid, id_mu, "MemoryOrder", "XYZ ")
                         call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "coordinates", "XLONG XLAT XTIME")
+                        error = nf90_put_att(ncid, id_mu, "coordinates", "XLONG XLAT XTIME")
                         call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "units", target_hist_units_3d_nz(i))
+                        error = nf90_put_att(ncid, id_mu, "units", target_hist_units_3d_nz(i))
                         call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "description", target_hist_longname_3d_nz(i))
+                        error = nf90_put_att(ncid, id_mu, "description", 'Perturbation '//target_hist_longname_3d_nz(i))
                         call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "stagger", "")
+                        error = nf90_put_att(ncid, id_mu, "stagger", "")
                         call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "FieldType", 104)
+                        error = nf90_put_att(ncid, id_mu, "FieldType", 104)
                         call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "_FillValue", missing_value)
+                        error = nf90_put_att(ncid, id_mu, "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
+                        error =  nf90_var_par_access(ncid, id_mu, NF90_COLLECTIVE)
+                        call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
+                    end if
 
-                        if (wrf_mod_vars .and. trim(varname) == 'MUB') then
-                            print *, "- DEFINE ON FILE STAGGERED TARGET GRID MU"
-                            error = nf90_def_var(ncid, 'MU', NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_mu)
-                            call netcdf_err(error, 'DEFINING VAR')
-                            error = nf90_put_att(ncid, id_mu, "MemoryOrder", "XYZ ")
-                            call netcdf_err(error, 'DEFINING MEMORYORDER')
-                            error = nf90_put_att(ncid, id_mu, "coordinates", "XLONG XLAT XTIME")
-                            call netcdf_err(error, 'DEFINING COORD')
-                            error = nf90_put_att(ncid, id_mu, "units", target_hist_units_3d_nz(i))
-                            call netcdf_err(error, 'DEFINING UNITS')
-                            error = nf90_put_att(ncid, id_mu, "description", 'Perturbation '//target_hist_longname_3d_nz(i))
-                            call netcdf_err(error, 'DEFINING LONG_NAME')
-                            error = nf90_put_att(ncid, id_mu, "stagger", "")
-                            call netcdf_err(error, 'DEFINING STAGGER')
-                            error = nf90_put_att(ncid, id_mu, "FieldType", 104)
-                            call netcdf_err(error, 'DEFINING FieldType')
-                            error = nf90_put_att(ncid, id_mu, "_FillValue", missing_value)
-                            call netcdf_err(error, 'DEFINING _FillValue')
-                        end if
-
-                        if (wrf_mod_vars .and. trim(varname) == 'P_HYD') then
-                            print *, "- DEFINE ON FILE STAGGERED TARGET GRID P_TOP"
-                            error = nf90_def_var(ncid, 'P_TOP', NF90_FLOAT, (/dim_time/), id_ptop)
-                            call netcdf_err(error, 'DEFINING VAR')
-                            error = nf90_put_att(ncid, id_ptop, "MemoryOrder", "0 ")
-                            call netcdf_err(error, 'DEFINING MEMORYORDER')
-                            error = nf90_put_att(ncid, id_ptop, "units", target_hist_units_3d_nz(i))
-                            call netcdf_err(error, 'DEFINING UNITS')
-                            error = nf90_put_att(ncid, id_ptop, "description", 'PRESSURE TOP OF THE MODEL')
-                            call netcdf_err(error, 'DEFINING LONG_NAME')
-                            error = nf90_put_att(ncid, id_ptop, "stagger", "")
-                            call netcdf_err(error, 'DEFINING STAGGER')
-                            error = nf90_put_att(ncid, id_ptop, "FieldType", 104)
-                            call netcdf_err(error, 'DEFINING FieldType')
-                            error = nf90_put_att(ncid, id_ptop, "_FillValue", missing_value)
-                            call netcdf_err(error, 'DEFINING _FillValue')
-                        end if
-                    !end if
+                    if (wrf_mod_vars .and. trim(varname) == 'P_HYD') then
+                        if (localpet == 0) print *, "- DEFINE ON FILE STAGGERED TARGET GRID P_TOP"
+                        error = nf90_def_var(ncid, 'P_TOP', NF90_FLOAT, (/dim_time/), id_ptop)
+                        call netcdf_err(error, 'DEFINING VAR')
+                        error = nf90_put_att(ncid, id_ptop, "MemoryOrder", "0 ")
+                        call netcdf_err(error, 'DEFINING MEMORYORDER')
+                        error = nf90_put_att(ncid, id_ptop, "units", target_hist_units_3d_nz(i))
+                        call netcdf_err(error, 'DEFINING UNITS')
+                        error = nf90_put_att(ncid, id_ptop, "description", 'PRESSURE TOP OF THE MODEL')
+                        call netcdf_err(error, 'DEFINING LONG_NAME')
+                        error = nf90_put_att(ncid, id_ptop, "stagger", "")
+                        call netcdf_err(error, 'DEFINING STAGGER')
+                        error = nf90_put_att(ncid, id_ptop, "FieldType", 104)
+                        call netcdf_err(error, 'DEFINING FieldType')
+                        error = nf90_put_att(ncid, id_ptop, "_FillValue", missing_value)
+                        call netcdf_err(error, 'DEFINING _FillValue')
+                        error =  nf90_var_par_access(ncid, id_ptop, NF90_COLLECTIVE)
+                        call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
+                    end if
                 end do
                 deallocate (fields)
             end if
-            !if (localpet==0) then 
             if (do_u_interp==1) then
-               print *, "- DEFINE ON FILE STAGGERED TARGET GRID U"
+               if (localpet == 0) print *, "- DEFINE ON FILE STAGGERED TARGET GRID U"
                error = nf90_def_var(ncid, "U", NF90_FLOAT, (/dim_lon_stag, dim_lat, dim_z, dim_time/),id_u)
                call netcdf_err(error, 'DEFINING VAR U')
                error = nf90_put_att(ncid, id_u, "MemoryOrder", "XYZ ")
@@ -871,10 +877,12 @@ contains
                call netcdf_err(error, 'DEFINING FieldType')
                error = nf90_put_att(ncid, id_u, "_FillValue", missing_value)
                call netcdf_err(error, 'DEFINING _FillValue')
+               error =  nf90_var_par_access(ncid, id_u, NF90_COLLECTIVE)
+               call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
             endif
 
             if (do_v_interp==1) then
-               print *, "- DEFINE ON FILE STAGGERED TARGET GRID v"
+               if (localpet == 0) print *, "- DEFINE ON FILE STAGGERED TARGET GRID v"
                error = nf90_def_var(ncid, "V", NF90_FLOAT, (/dim_lon, dim_lat_stag, dim_z, dim_time/),id_v)
                call netcdf_err(error, 'DEFINING VAR V')
                error = nf90_put_att(ncid, id_v, "MemoryOrder", "XYZ ")
@@ -891,8 +899,9 @@ contains
                call netcdf_err(error, 'DEFINING FieldType')
                error = nf90_put_att(ncid, id_v, "_FillValue", missing_value)
                call netcdf_err(error, 'DEFINING _FillValue')
+               error =  nf90_var_par_access(ncid, id_v, NF90_COLLECTIVE)
+               call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
             endif
-            !endif
 
             if (n_hist_fields_3d_nzp1 > 0) then
                 allocate (fields(n_hist_fields_3d_nzp1))
@@ -905,51 +914,53 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_zp1, dim_time/), id_vars3_nzp1(i))
+                    if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
+                    error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_zp1, dim_time/), id_vars3_nzp1(i))
+                    call netcdf_err(error, 'DEFINING VAR')
+                    error = nf90_put_att(ncid, id_vars3_nzp1(i), "MemoryOrder", "XYZ ")
+                    call netcdf_err(error, 'DEFINING MEMORYORDER')
+                    error = nf90_put_att(ncid, id_vars3_nzp1(i), "coordinates", "XLONG XLAT XTIME")
+                    call netcdf_err(error, 'DEFINING COORD')
+                    if (wrf_mod_vars .and. trim(varname) == 'PHB') then
+                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "units", "gpm")
+                        call netcdf_err(error, 'DEFINING UNITS')
+                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "description", "Base Geopotential Height")
+                        call netcdf_err(error, 'DEFINING LONG_NAME')
+                    else
+                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "units", target_hist_units_3d_nzp1(i))
+                        call netcdf_err(error, 'DEFINING UNITS')
+                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "description", target_hist_longname_3d_nzp1(i))
+                        call netcdf_err(error, 'DEFINING LONG_NAME')
+                    end if
+                    error = nf90_put_att(ncid, id_vars3_nzp1(i), "stagger", "Z")
+                    call netcdf_err(error, 'DEFINING STAGGER')
+                    error = nf90_put_att(ncid, id_vars3_nzp1(i), "FieldType", 104)
+                    call netcdf_err(error, 'DEFINING FieldType')
+                    error = nf90_put_att(ncid, id_vars3_nzp1(i), "_FillValue", missing_value)
+                    call netcdf_err(error, 'DEFINING _FillValue')
+                    error =  nf90_var_par_access(ncid, id_vars3_nzp1(i), NF90_COLLECTIVE)
+                    call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
+                    if (wrf_mod_vars .and. trim(varname) == 'PHB') then
+                        if (localpet == 0) print *, "- DEFINE ON FILE STAGGERED TARGET GRID PH"
+                        error = nf90_def_var(ncid, 'PH', NF90_FLOAT, (/dim_lon, dim_lat, dim_zp1, dim_time/), id_ph)
                         call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "MemoryOrder", "XYZ ")
+                        error = nf90_put_att(ncid, id_ph, "MemoryOrder", "XYZ ")
                         call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "coordinates", "XLONG XLAT XTIME")
+                        error = nf90_put_att(ncid, id_ph, "coordinates", "XLONG XLAT XTIME")
                         call netcdf_err(error, 'DEFINING COORD')
-                        if (wrf_mod_vars .and. trim(varname) == 'PHB') then
-                            error = nf90_put_att(ncid, id_vars3_nzp1(i), "units", "gpm")
-                            call netcdf_err(error, 'DEFINING UNITS')
-                            error = nf90_put_att(ncid, id_vars3_nzp1(i), "description", "Base Geopotential Height")
-                            call netcdf_err(error, 'DEFINING LONG_NAME')
-                        else
-                            error = nf90_put_att(ncid, id_vars3_nzp1(i), "units", target_hist_units_3d_nzp1(i))
-                            call netcdf_err(error, 'DEFINING UNITS')
-                            error = nf90_put_att(ncid, id_vars3_nzp1(i), "description", target_hist_longname_3d_nzp1(i))
-                            call netcdf_err(error, 'DEFINING LONG_NAME')
-                        end if
-                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "stagger", "Z")
+                        error = nf90_put_att(ncid, id_ph, "units", "gpm")
+                        call netcdf_err(error, 'DEFINING UNITS')
+                        error = nf90_put_att(ncid, id_ph, "description", 'Perturbation Geopotential Height')
+                        call netcdf_err(error, 'DEFINING LONG_NAME')
+                        error = nf90_put_att(ncid, id_ph, "stagger", "Z")
                         call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "FieldType", 104)
+                        error = nf90_put_att(ncid, id_ph, "FieldType", 104)
                         call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars3_nzp1(i), "_FillValue", missing_value)
+                        error = nf90_put_att(ncid, id_ph, "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                        if (wrf_mod_vars .and. trim(varname) == 'PHB') then
-                            print *, "- DEFINE ON FILE STAGGERED TARGET GRID PH"
-                            error = nf90_def_var(ncid, 'PH', NF90_FLOAT, (/dim_lon, dim_lat, dim_zp1, dim_time/), id_ph)
-                            call netcdf_err(error, 'DEFINING VAR')
-                            error = nf90_put_att(ncid, id_ph, "MemoryOrder", "XYZ ")
-                            call netcdf_err(error, 'DEFINING MEMORYORDER')
-                            error = nf90_put_att(ncid, id_ph, "coordinates", "XLONG XLAT XTIME")
-                            call netcdf_err(error, 'DEFINING COORD')
-                            error = nf90_put_att(ncid, id_ph, "units", "gpm")
-                            call netcdf_err(error, 'DEFINING UNITS')
-                            error = nf90_put_att(ncid, id_ph, "description", 'Perturbation Geopotential Height')
-                            call netcdf_err(error, 'DEFINING LONG_NAME')
-                            error = nf90_put_att(ncid, id_ph, "stagger", "Z")
-                            call netcdf_err(error, 'DEFINING STAGGER')
-                            error = nf90_put_att(ncid, id_ph, "FieldType", 104)
-                            call netcdf_err(error, 'DEFINING FieldType')
-                            error = nf90_put_att(ncid, id_ph, "_FillValue", missing_value)
-                            call netcdf_err(error, 'DEFINING _FillValue')
-                        end if
-                    !end if
+                        error =  nf90_var_par_access(ncid, id_ph, NF90_COLLECTIVE)
+                        call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
+                    end if
                 end do
                 deallocate (fields)
             end if
@@ -965,34 +976,34 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    !if (localpet == 0) then
-                        print *, "- DEFINE ON FILE TARGET GRID ", varname
-                        error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_vert(i))
-                        call netcdf_err(error, 'DEFINING VAR')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "MemoryOrder", "XYZ")
-                        call netcdf_err(error, 'DEFINING MEMORYORDER')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "coordinates", "XLONG XLAT XTIME")
-                        call netcdf_err(error, 'DEFINING COORD')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "units", target_hist_units_3d_vert(i))
-                        call netcdf_err(error, 'DEFINING UNITS')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "description", target_hist_longname_3d_vert(i))
-                        call netcdf_err(error, 'DEFINING LONG_NAME')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "stagger", "")
-                        call netcdf_err(error, 'DEFINING STAGGER')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "FieldType", 104)
-                        call netcdf_err(error, 'DEFINING FieldType')
-                        error = nf90_put_att(ncid, id_vars3_vert(i), "_FillValue", missing_value)
-                        call netcdf_err(error, 'DEFINING _FillValue')
-                    !end if
+                    if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
+                    error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_vert(i))
+                    call netcdf_err(error, 'DEFINING VAR')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "MemoryOrder", "XYZ")
+                    call netcdf_err(error, 'DEFINING MEMORYORDER')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "coordinates", "XLONG XLAT XTIME")
+                    call netcdf_err(error, 'DEFINING COORD')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "units", target_hist_units_3d_vert(i))
+                    call netcdf_err(error, 'DEFINING UNITS')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "description", target_hist_longname_3d_vert(i))
+                    call netcdf_err(error, 'DEFINING LONG_NAME')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "stagger", "")
+                    call netcdf_err(error, 'DEFINING STAGGER')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "FieldType", 104)
+                    call netcdf_err(error, 'DEFINING FieldType')
+                    error = nf90_put_att(ncid, id_vars3_vert(i), "_FillValue", missing_value)
+                    call netcdf_err(error, 'DEFINING _FillValue')
+                    error =  nf90_var_par_access(ncid, id_vars3_vert(i), NF90_COLLECTIVE)
+                    call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
                 end do
                 deallocate (fields)
             end if
         end if !write hist
 
-        IF (wrf_mod_vars ) THEN !.AND. localpet == 0) THEN
+        IF (wrf_mod_vars ) THEN 
             ! define dummy 3d fields
             varname = 'P'
-            print *, "- DEFINE ON FILE TARGET GRID ", varname
+            if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
             error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_dummy3d_p)
             call netcdf_err(error, 'DEFINING VAR')
             error = nf90_put_att(ncid, id_dummy3d_p, "MemoryOrder", "XYZ ")
@@ -1009,9 +1020,11 @@ contains
             call netcdf_err(error, 'DEFINING FieldType')
             error = nf90_put_att(ncid, id_dummy3d_p, "_FillValue", missing_value)
             call netcdf_err(error, 'DEFINING _FillValue')
+            error =  nf90_var_par_access(ncid, id_dummy3d_p, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
 
             varname = 'PB'
-            print *, "- DEFINE ON FILE TARGET GRID ", varname
+            if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
             error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_dummy3d_pb)
             call netcdf_err(error, 'DEFINING VAR')
             error = nf90_put_att(ncid, id_dummy3d_pb, "MemoryOrder", "XYZ ")
@@ -1028,13 +1041,13 @@ contains
             call netcdf_err(error, 'DEFINING FieldType')
             error = nf90_put_att(ncid, id_dummy3d_pb, "_FillValue", missing_value)
             call netcdf_err(error, 'DEFINING _FillValue')
+            error =  nf90_var_par_access(ncid, id_dummy3d_pb, NF90_COLLECTIVE)
+            call netcdf_err(error ,'SETTING COLLECTIVE ACCESS')
          END IF
 
-        !if (localpet == 0) then
-            print*, "END DEFINE MODE"
-            error = nf90_enddef(ncid, header_buffer_val, 4, 0, 4)
-            call netcdf_err(error, 'DEFINING HEADER')
-        !end if
+         print*, "END DEFINE MODE"
+         error = nf90_enddef(ncid, header_buffer_val, 4, 0, 4)
+         call netcdf_err(error, 'DEFINING HEADER')
 
 !--- write fields
 
@@ -1049,12 +1062,9 @@ contains
         count2 = cub(2)-clb(2)+1
         allocate(dum2d(count1,count2))
         dum2d(:,:) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
-        !if (localpet == 0) then
-            !dum2dt(:, :, 1) = dum2d
-            error = nf90_put_var(ncid, id_lon, dum2d, start = (/clb(1),clb(2),1/),  &
+        error = nf90_put_var(ncid, id_lon, dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
-            call netcdf_err(error, 'WRITING LONGITUDE RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING LONGITUDE RECORD')
 
 !  latitude
 
@@ -1062,14 +1072,11 @@ contains
         call ESMF_FieldGet(latitude_target_grid, farrayPtr=dum2dptr, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGet", error)
-		
-		dum2d(:,:) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
-        !if (localpet == 0) then
-            dum2(:, :) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
-            error = nf90_put_var(ncid, id_lat, dum2d, start = (/clb(1),clb(2),1/),  &
+
+        dum2d(:, :) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+        error = nf90_put_var(ncid, id_lat, dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
-            call netcdf_err(error, 'WRITING LATITUDE RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING LATITUDE RECORD')
 
 
 !  longitude on u grid
@@ -1083,12 +1090,9 @@ contains
         count2u = cubu(2)-clbu(2)+1
         allocate(dum2du(count1u,count2u))    
         dum2du = dum2dptr(clb(1):cub(1),clb(2):cub(2))
-        !if (localpet == 0) then
-            dum2dtu(:,:,1) = dum2du
-            error = nf90_put_var(ncid, id_lonu, dum2du, start = (/clbu(1),clbu(2),1/),  &
+        error = nf90_put_var(ncid, id_lonu, dum2du, start = (/clbu(1),clbu(2),1/),  &
                                    count=(/count1u, count2u, 1/))
-            call netcdf_err(error, 'WRITING XLONG_U RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING XLONG_U RECORD')
 
 !  latitude on u grid
 
@@ -1098,14 +1102,12 @@ contains
             call error_handler("IN FieldGet", error)
             
         dum2du = dum2dptr(clbu(1):cubu(1),clbu(2):cubu(2))
-        !if (localpet == 0) then
-            error = nf90_put_var(ncid, id_latu, dum2du, start = (/clbu(1),clbu(2),1/),  &
+        error = nf90_put_var(ncid, id_latu, dum2du, start = (/clbu(1),clbu(2),1/),  &
                                    count=(/count1u, count2u, 1/))
-            call netcdf_err(error, 'WRITING XLAT_U RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING XLAT_U RECORD')
 
 !  latitude on v grid
-		if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LATITUDE V"
+        if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LATITUDE V"
         call ESMF_FieldGet(latitude_v_target_grid, farrayPtr=dum2dptr, computationalLBound=clbv,&
                              computationalUBound = cubv, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
@@ -1116,26 +1118,21 @@ contains
         allocate(dum2dv(count1v,count2v))
     
         dum2dv = dum2dptr(clbv(1):cubv(1),clbv(2):cubv(2))
-        !if (localpet == 0) then
-            error = nf90_put_var(ncid, id_latv, dum2dv, start = (/clb(1),clb(2),1/),  &
+        error = nf90_put_var(ncid, id_latv, dum2dv, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1v, count2v, 1/))
-            call netcdf_err(error, 'WRITING XLAT_U RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING XLAT_U RECORD')
 
 !  longitude on v grid
         if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID LONGITUDE V"
-        call ESMF_FieldGet(longitude_v_target_grid, farrayPtr=dum2dptr,computationalLBound=clb,&
-                             computationalUBound = cub, rc=error)
+        call ESMF_FieldGet(longitude_v_target_grid, farrayPtr=dum2dptr,rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGet", error)
             
 
         dum2dv = dum2dptr(clbv(1):cubv(1),clbv(2):cubv(2))
-        !if (localpet == 0) then
-            error = nf90_put_var(ncid, id_lonv, dum2dv, start = (/clb(1),clb(2),1/),  &
+        error = nf90_put_var(ncid, id_lonv, dum2dv, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1v, count2v, 1/))
-            call netcdf_err(error, 'WRITING XLAT_U RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING XLAT_U RECORD')
 
 ! mapfac on mass grid
 
@@ -1144,12 +1141,10 @@ contains
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGet", error)
             
-		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
-        !if (localpet == 0) then
-            error = nf90_put_var(ncid, id_mfm, dum2d, start = (/clb(1),clb(2),1/),  &
+        dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+        error = nf90_put_var(ncid, id_mfm, dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
-            call netcdf_err(error, 'WRITING MAPFAC_M RECORD')
-        !end if
+        call netcdf_err(error, 'WRITING MAPFAC_M RECORD')
 
 ! mapfac on u grid
 
@@ -1159,43 +1154,42 @@ contains
             call error_handler("IN FieldGet", error)
             
         dum2du = dum2dptr(clbu(1):cubu(1),clbu(2):cubu(2))
-            error = nf90_put_var(ncid, id_mfu, dum2du, start = (/clbu(1),clbu(2),1/),  &
+        error = nf90_put_var(ncid, id_mfu, dum2du, start = (/clbu(1),clbu(2),1/),  &
                                    count=(/count1u, count2u, 1/))
-            call netcdf_err(error, 'WRITING MAPFAC_U RECORD')
+        call netcdf_err(error, 'WRITING MAPFAC_U RECORD')
 
 !mapfac on v grid
 
         if (localpet == 0) print *, "- CALL FieldGet FOR TARGET GRID mapfac_v"
-        call ESMF_FieldGet(mapfac_v_target_grid, farrayPtr=dum2dptr, computationalLBound=clb,&
-                             computationalUBound = cub, rc=error)
+        call ESMF_FieldGet(mapfac_v_target_grid, farrayPtr=dum2dptr, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGet", error)
             
 
         dum2dv = dum2dptr(clbv(1):cubv(1),clbv(2):cubv(2))
-            error = nf90_put_var(ncid, id_mfv, dum2du, start = (/clb(1),clb(2),1/),  &
+        error = nf90_put_var(ncid, id_mfv, dum2du, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1v, count2v, 1/))
-            call netcdf_err(error, 'WRITING MAPFAC_V RECORD')
+        call netcdf_err(error, 'WRITING MAPFAC_V RECORD')
 
         if (PROJ_CODE==PROJ_LC .or. PROJ_CODE==PROJ_CASSINI) then
 !sinalpha
-        if (localpet == 0) print*, "- CALL FieldGather FOR TARGET GRID sinalpha"
-        call ESMF_FieldGet(sina_target_grid, farrayPtr=dum2dptr, rc=error)
-        if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGet", error)
+            if (localpet == 0) print*, "- CALL FieldGather FOR TARGET GRID sinalpha"
+            call ESMF_FieldGet(sina_target_grid, farrayPtr=dum2dptr, rc=error)
+             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
+              call error_handler("IN FieldGet", error)
             
-		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+            dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
             error = nf90_put_var(ncid, id_sina, dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
             call netcdf_err(error, 'WRITING SINALPHA RECORD')
 
 !cosalpha
-        if (localpet == 0) print*, "- CALL FieldGather FOR TARGET GRID cosalpha"
-        call ESMF_FieldGet(cosa_target_grid, farrayPtr=dum2dptr, rc=error)
-        if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-            call error_handler("IN FieldGet", error)
+            if (localpet == 0) print*, "- CALL FieldGather FOR TARGET GRID cosalpha"
+            call ESMF_FieldGet(cosa_target_grid, farrayPtr=dum2dptr, rc=error)
+             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
+              call error_handler("IN FieldGet", error)
             
-		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+            dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
             error = nf90_put_var(ncid, id_cosa, dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
             call netcdf_err(error, 'WRITING COSALPHA RECORD')
@@ -1203,10 +1197,8 @@ contains
 !  z_s
 
         if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID Z_S"
-        if (localpet == 0) then
-            error = nf90_put_var(ncid, id_zs, zs_target_grid, count=(/nsoil_input, 1/))
-            call netcdf_err(error, 'WRITING ZS RECORD')
-        end if
+        error = nf90_put_var(ncid, id_zs, zs_target_grid, count=(/nsoil_input, 1/))
+        call netcdf_err(error, 'WRITING ZS RECORD')
 
 !  hgt
 
@@ -1215,11 +1207,11 @@ contains
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGet", error)
             
-		dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
-		if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID HGT"
-            error = nf90_put_var(ncid, id_hgt, dum2d, start = (/clb(1),clb(2),1/),  &
+        dum2d = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+        if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID HGT"
+        error = nf90_put_var(ncid, id_hgt, dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
-            call netcdf_err(error, 'WRITING HGT RECORD')
+        call netcdf_err(error, 'WRITING HGT RECORD')
 !   u
        if (do_u_interp == 1) then
           if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID U"
@@ -1231,10 +1223,10 @@ contains
              call error_handler("IN FieldGet", error)
 
           if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID U"
-		  dum3dtmp(:,:,:) = dum3dptr(clbu(1):cubu(1),clbu(2):cub(2),:)
-              error = nf90_put_var(ncid, id_u, dum3dtmp,  start = (/clbu(1),clbu(2),1,1/),  &
+          dum3dtmp(:,:,:) = dum3dptr(clbu(1):cubu(1),clbu(2):cubu(2),:)
+          error = nf90_put_var(ncid, id_u, dum3dtmp,  start = (/clbu(1),clbu(2),1,1/),  &
                                    count=(/count1u, count2u, nz_input,1/))
-              call netcdf_err(error, 'WRITING U RECORD')
+          call netcdf_err(error, 'WRITING U RECORD')
 
           deallocate(dum3dtmp)
        endif
@@ -1248,61 +1240,55 @@ contains
           call ESMF_FieldGet(v_target_grid, farrayPtr=dum3dptr, rc=error)
           if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
              call error_handler("IN FieldGet", error)
-          dum3dtmp(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
+          dum3dtmp(:,:,:) = dum3dptr(clbv(1):cubv(1),clbv(2):cubv(2),:)
 
           if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID V"
-	  ! set to use MPI/PnetCDF collective I/O
-	  error =  nf90_var_par_access(ncid, id_v, NF90_COLLECTIVE)
-	  call netcdf_err(error ,'SETTING PAR ACCESS ON V')
-	  error = nf90_put_var(ncid, id_v, dum3dtmp, start = (/clbv(1),clbv(2),1,1/),  &
-						   count=(/count1v, count2v, nz_input, 1/))
-	  call netcdf_err(error, 'WRITING V RECORD')
+          ! set to use MPI/PnetCDF collective I/O
+          error =  nf90_var_par_access(ncid, id_v, NF90_COLLECTIVE)
+          call netcdf_err(error ,'SETTING PAR ACCESS ON V')
+          error = nf90_put_var(ncid, id_v, dum3dtmp, start = (/clbv(1),clbv(2),1,1/),  &
+                           count=(/count1v, count2v, nz_input, 1/))
+          call netcdf_err(error, 'WRITING V RECORD')
           deallocate(dum3dtmp)
        endif
 
 !  times
 
         if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID Times"
-        if (localpet == 0) then
-            tempstr(1, :) = valid_time(1, 1:Datestrlen)
-            error = nf90_put_var(ncid, id_times, tempstr, start=(/1, 1/), count=(/Datestrlen, 1/))
-            call netcdf_err(error, 'WRITING TIMES RECORD')
-        end if
+         tempstr(1, :) = valid_time(1, 1:Datestrlen)
+         error = nf90_put_var(ncid, id_times, tempstr, start=(/1, 1/), count=(/Datestrlen, 1/))
+         call netcdf_err(error, 'WRITING TIMES RECORD')
 
 !  xtime
 
         if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID ITIMESTEP"
-        if (localpet == 0) then
-            sy = substr(start_time, 1, 4)
-            sm = substr(start_time, 6, 7)
-            sd = substr(start_time, 9, 10)
-            sh = substr(start_time, 12, 13)
-            smi = substr(start_time, 15, 16)
-            ss = substr(start_time, 18, 19)
+        sy = substr(start_time, 1, 4)
+        sm = substr(start_time, 6, 7)
+        sd = substr(start_time, 9, 10)
+        sh = substr(start_time, 12, 13)
+        smi = substr(start_time, 15, 16)
+        ss = substr(start_time, 18, 19)
 
-            vy = substr(valid_time(1, 1), 1, 4)
-            vm = substr(valid_time(1, 1), 6, 7)
-            vd = substr(valid_time(1, 1), 9, 10)
-            vh = substr(valid_time(1, 1), 12, 13)
-            vmi = substr(valid_time(1, 1), 15, 16)
-            vs = substr(valid_time(1, 1), 18, 19)
-            xtime_dt = datetime(sy, sm, sd, sh, smi, ss) - datetime(vy, vm, vd, vh, vmi, vs)
+        vy = substr(valid_time(1, 1), 1, 4)
+        vm = substr(valid_time(1, 1), 6, 7)
+        vd = substr(valid_time(1, 1), 9, 10)
+        vh = substr(valid_time(1, 1), 12, 13)
+        vmi = substr(valid_time(1, 1), 15, 16)
+        vs = substr(valid_time(1, 1), 18, 19)
+        xtime_dt = datetime(sy, sm, sd, sh, smi, ss) - datetime(vy, vm, vd, vh, vmi, vs)
 
-            error = nf90_put_var(ncid, id_xtime, (/xtime_dt%total_seconds()/60.0/), count=(/1/))
-            call netcdf_err(error, 'WRITING XTIME RECORD')
-        end if
+        error = nf90_put_var(ncid, id_xtime, (/xtime_dt%total_seconds()/60.0/), count=(/1/))
+        call netcdf_err(error, 'WRITING XTIME RECORD')
 
         !  itimestep
 
         if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID ITIMESTEP"
-        if (localpet == 0) then
-            if (config_dt > 0.0) then
-                error = nf90_put_var(ncid, id_itime, (/int(xtime_dt%total_seconds()/config_dt)/), count=(/1/))
-                call netcdf_err(error, 'WRITING ITIMESTEP RECORD')
-            else
-                error = nf90_put_var(ncid, id_itime, (/0/), count=(/1/))
-                call netcdf_err(error, 'WRITING ITIMESTEP RECORD')
-            end if
+        if (config_dt > 0.0) then
+            error = nf90_put_var(ncid, id_itime, (/int(xtime_dt%total_seconds()/config_dt)/), count=(/1/))
+            call netcdf_err(error, 'WRITING ITIMESTEP RECORD')
+        else
+            error = nf90_put_var(ncid, id_itime, (/0/), count=(/1/))
+            call netcdf_err(error, 'WRITING ITIMESTEP RECORD')
         end if
         deallocate (dumsmall)
 
@@ -1313,22 +1299,18 @@ contains
             call ESMF_FieldGet(field_write_2d(i), name=varname, rc=error)
             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                 call error_handler("IN FieldGet", error)
-
-            if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID ", trim(varname)
-            call ESMF_FieldGather(field_write_2d(i), dum2d, rootPet=0, rc=error)
+            call ESMF_FieldGet(field_write_2d(i), farrayPtr = dum2dptr, rc=error)
             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                call error_handler("IN FieldGather", error)
+                call error_handler("IN FieldGet", error)
 
-            if (localpet == 0) then
-                print *, "- WRITE TO FILE ", trim(varname)
-                dum2dt(:, :, 1) = dum2d
-                error = nf90_put_var(ncid, id_vars2(i), dum2dt, start = (/clb(1),clb(2),1/),  &
+            if (localpet == 0) print *, "- WRITE TO FILE ", trim(varname)
+            dum2d(:, :) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
+            error = nf90_put_var(ncid, id_vars2(i), dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
-                call netcdf_err(error, 'WRITING RECORD')
-            end if
+            call netcdf_err(error, 'WRITING RECORD')
         end do
         deallocate (field_write_2d)
-        deallocate (dum2d, dum2dt)
+        deallocate (dum2d)
 
         !    3d fields from diaglist
 
@@ -1338,18 +1320,15 @@ contains
                 call ESMF_FieldGet(field_extra3(i), name=varname, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
-
-                if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID ", trim(varname)
-                call ESMF_FieldGather(field_extra3(i), dum3d, rootPet=0, rc=error)
+                call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGather", error)
+                    call error_handler("IN FieldGet", error)                
 
-                if (localpet == 0) then
-                    print *, trim(varname), minval(dum3d), maxval(dum3d)
-                    dum3dt(:, :, :, 1) = dum3d
-                    error = nf90_put_var(ncid, id_vars3_nz(i), dum3dt, count=(/i_target, j_target, nz_input, 1/))
-                    call netcdf_err(error, 'WRITING RECORD')
-                end if
+                dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
+                if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)
+                 error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/clb(1),clb(2),1,1/), &
+                                count=(/count1,count2, nz_input, 1/))
+                 call netcdf_err(error, 'WRITING RECORD')
             end do
         end if
         ! 3d soil fields
@@ -1361,27 +1340,25 @@ contains
                                      rc=error)
             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                 call error_handler("IN FieldBundleGet", error)
-
+            if(allocated(dumsoil)) deallocate(dumsoil)
+            allocate(dumsoil(count1,count2,nsoil_input))
             do i = 1, n_hist_fields_soil
                 call ESMF_FieldGet(fields(i), name=varname, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
-
-                if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID ", trim(varname)
-                call ESMF_FieldGather(fields(i), dumsoil, rootPet=0, rc=error)
+                call ESMF_FieldGet(fields(i), farrayPtr=dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGather", error)
+                    call error_handler("IN FieldGet", error)
 
-                if (localpet == 0) then
-                    print *, trim(varname), minval(dumsoil), maxval(dumsoil)
-                    dumsoilt(:, :, :, 1) = dumsoil
-                    error = nf90_put_var(ncid, id_vars_soil(i), dumsoilt, count=(/i_target, j_target, nsoil_input, 1/))
-                    call netcdf_err(error, 'WRITING RECORD')
-                end if
+                dumsoil(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
+                if (localpet == 0)  print *, trim(varname), minval(dumsoil), maxval(dumsoil)
+                 error = nf90_put_var(ncid, id_vars_soil(i), dumsoil, start = (/clb(1),clb(2),1,1/), &
+                                count=(/count1,count2, nsoil_input, 1/))
+                 call netcdf_err(error, 'WRITING RECORD')
             end do
             deallocate (fields)
         end if
-        deallocate (dumsoil, dumsoilt)
+        deallocate (dumsoil)
 
         ! 3d nz fieldsi from histlist
 
@@ -1392,12 +1369,13 @@ contains
                                      rc=error)
             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                 call error_handler("IN FieldBundleGet", error)
-
+            if (allocated(dum3d)) deallocate(dum3d)
+            allocate(dum3d(clb(1):cub(1),clb(2):cub(2),nz_input))
             do n = 1, n_hist_fields_3d_nz
                 call ESMF_FieldGet(fields(n), name=varname, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
-                call ESMF_FieldGather(fields(n), dum3d, rootPet=0, rc=error)
+                call ESMF_FieldGet(fields(n), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGather", error)
                 if (localpet == 0) then
@@ -1419,33 +1397,47 @@ contains
                                              count=(/i_target, j_target, nz_input, 1/))
                         call netcdf_err(error, 'WRITING RECORD')
 
-                        if (wrf_mod_vars .and. trim(varname) == 'MUB') then
-                            dum3dt(:, :, :, 1) = 0.0_esmf_kind_r8
-                            print *, 'MU', minval(dum3d), maxval(dum3d)
-                            error = nf90_put_var(ncid, id_mu, dum3dt, &
-                                                 count=(/i_target, j_target, nz_input, 1/))
-                            call netcdf_err(error, 'WRITING RECORD')
-                        end if
+                if (wrf_mod_vars .and. trim(varname) == 'T') then
+                    do i = clb(1),cub(1)
+                    do j = clb(2),cub(2)
+                        if (dum3dptr(i, j,1) == missing_value) cycle
+                        dum3d(i, j, :) = dum3dptr(i, j, :) - 300.0
+                    end do
+                    end do
+                else
+                   dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
+                end if
+                if (localpet==0) print *, trim(varname), minval(dum3d), maxval(dum3d)
+                error = nf90_put_var(ncid, id_vars3_nz(n + n3d), dum3d, start = (/clb(1),clb(2),1,1/), &
+                                     count=(/count1, count2, nz_input, 1/))
+                call netcdf_err(error, 'WRITING RECORD')
 
-                        if (wrf_mod_vars .and. trim(varname) == 'P_HYD') then
-                            dum1d(1) = maxval(dum3d)
-                            do i = 1, i_target
-                            do j = 1, j_target
-                                if (.not. dum3d(i, j, nz_input)== missing_value) then
-                                    dum1d(1) = min(dum3d(i, j, nz_input)*0.80_esmf_kind_r8, dum1d(1))
-                                end if
-                            end do
-                            end do
-                            error = nf90_put_var(ncid, id_ptop, dum1d, count=(/1/))
-                            call netcdf_err(error, 'WRITING RECORD')
+                if (wrf_mod_vars .and. trim(varname) == 'MUB') then
+                    dum3d(:, :, :) = 0.0_esmf_kind_r8
+                    if (localpet==0) print *, 'MU', minval(dum3d), maxval(dum3d)
+                    error = nf90_put_var(ncid, id_mu, dum3d, start = (/clb(1),clb(2),1,1/), &
+                                              count=(/count1, count2, nz_input, 1/))
+                    call netcdf_err(error, 'WRITING RECORD')
+                end if
 
-                            ! WRITE PB also
-                            print *, 'PB', minval(dum3dt), maxval(dum3dt)
-                            error = nf90_put_var(ncid, id_dummy3d_pb, dum3dt, &
-                                                 count=(/i_target, j_target, nz_input, 1/))
-                            call netcdf_err(error, 'WRITING RECORD')
-                        endif !P_HYD
-                end if !localpet==0
+                if (wrf_mod_vars .and. trim(varname) == 'P_HYD') then
+                   dum1d(1) = maxval(dum3d)
+                   do i = clb(1),cub(1)
+                   do j = clb(2),cub(2)
+                      if (.not. dum3d(i, j, nz_input)== missing_value) then
+                         dum1d(1) = min(dum3d(i, j, nz_input)*0.80_esmf_kind_r8, dum1d(1))
+                      end if
+                   end do
+                   end do
+                   error = nf90_put_var(ncid, id_ptop, dum1d, count=(/1/))
+                   call netcdf_err(error, 'WRITING RECORD')
+
+                   ! WRITE PB also
+                   if (localpet==0) print *, 'PB', minval(dum3d), maxval(dum3d)
+                   error = nf90_put_var(ncid, id_dummy3d_pb, dum3d, start = (/clb(1),clb(2),1,1/), &
+                                           count=(/count1, count2, nz_input, 1/))
+                   call netcdf_err(error, 'WRITING RECORD')
+                endif !P_HYD
             end do
             deallocate (fields)
         end if
@@ -1459,49 +1451,48 @@ contains
                                      rc=error)
             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                 call error_handler("IN FieldBundleGet", error)
-
+            if (allocated(dum3d)) deallocate(dum3d)
+            allocate(dum3d(clb(1):cub(1),clb(2):cub(2),nz_input+1))
             do i = 1, n_hist_fields_3d_nzp1
                 call ESMF_FieldGet(fields(i), name=varname, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
+                call ESMF_FieldGet(fields(i), farrayPtr = dum3dptr, rc=error)
+                if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
+                    call error_handler("IN FieldGet", error)
 
                 if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID ", trim(varname)
-                call ESMF_FieldGather(fields(i), dum3dp1, rootPet=0, rc=error)
-                if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGather", error)
+                if (trim(varname) == 'PHB') then
+                   do n = clb(1),cub(1)
+                   do j = clb(2),cub(2)
+                      if (dum3dptr(n,j,1) == missing_value) cycle
+                      do k = 2, nzp1_input
+                         dum3d(n, j, k - 1) = 0.5*(dum3dptr(n, j, k) + dum3dptr(n, j, k - 1))
+                         dum3d(n,j, k - 1) = dum3dptr(n,j, k - 1) * 9.81
+                      end do
+                   end do
+                   end do
 
-                if (localpet == 0) then
-                    if (trim(varname) == 'PHB') then
-                        do n = 1, i_target
-                        do j = 1, j_target
-                        if (dum3dp1(n,j,1) == missing_value) cycle
-                        do k = 2, nzp1_input
-                            dum3dt(n, j, k - 1, 1) = 0.5*(dum3dp1(n, j, k) + dum3dp1(n, j, k - 1))
-                            dum3dp1(n,j, k - 1) = dum3dp1(n,j, k - 1) * 9.81
-                        end do
-                        end do
-                        end do
-
-                        error = nf90_put_var(ncid, id_z, dum3dt, count=(/i_target, j_target, nz_input, 1/))
-                        call netcdf_err(error, 'WRITING RECORD')
+                   error = nf90_put_var(ncid, id_z, dum3d(:,:,1:nz_input), start = (/clb(1),clb(2),1,1/), & 
+                                count=(/count1, count2, nz_input, 1/))
+                   call netcdf_err(error, 'WRITING RECORD')
 
                         !dum3dp1 = dum3dp1*9.81
-                    end if
-
-                    print *, trim(varname), minval(dum3dp1), maxval(dum3dp1)
-                    dum3dp1t(:, :, :, 1) = dum3dp1
-                    error = nf90_put_var(ncid, id_vars3_nzp1(i), dum3dp1t, &
-                                         count=(/i_target, j_target, nz_input + 1, 1/))
-                    call netcdf_err(error, 'WRITING RECORD')
-
-                    if (wrf_mod_vars .and. trim(varname) == 'PHB') then
-                        dum3dp1t(:, :, :, 1) = 0.0_esmf_kind_r8
-                        error = nf90_put_var(ncid, id_ph, dum3dp1t, &
-                                             count=(/i_target, j_target, nz_input + 1, 1/))
-                        call netcdf_err(error, 'WRITING RECORD')
-                    end if
-
                 end if
+
+                dum3d(:, :, :) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
+                if (localpet==0) print *, trim(varname), minval(dum3d), maxval(dum3d)
+                error = nf90_put_var(ncid, id_vars3_nzp1(i), dum3d, start = (/clb(1),clb(2),1,1/), &
+                                        count=(/count1, count2, nz_input + 1, 1/))
+                call netcdf_err(error, 'WRITING RECORD')
+
+                if (wrf_mod_vars .and. trim(varname) == 'PHB') then
+                   dum3d(:, :, :) = 0.0_esmf_kind_r8
+                   error = nf90_put_var(ncid, id_ph, dum3d, start = (/clb(1),clb(2),1,1/), &
+                                         count=(/count1, count2, nz_input + 1, 1/))
+                   call netcdf_err(error, 'WRITING RECORD')
+                end if
+
             end do
             deallocate (fields)
         end if
@@ -1515,39 +1506,44 @@ contains
                                      rc=error)
             if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                 call error_handler("IN FieldBundleGet", error)
-                do i = 1, n_hist_fields_3d_vert
-                    call ESMF_FieldGet(fields(i), name=varname, rc=error)
-                    if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                        call error_handler("IN FieldGet", error)
-                    if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID ", trim(varname)
-                    call ESMF_FieldGather(fields(i), dum3d, rootPet=0, rc=error)
-                    if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                        call error_handler("IN FieldGather", error)
-                    if (localpet == 0) then
-                        print *, trim(varname), minval(dum3d), maxval(dum3d)
-                        dum3dt(:, :, :, 1) = dum3d
-                        error = nf90_put_var(ncid, id_vars3_vert(i), dum3dt, count=(/i_target, j_target, nz_input, 1/))
-                        call netcdf_err(error, 'WRITING RECORD')
-                    end if
-                end do
+            call ESMF_FieldGet(fields(1), farrayPtr = dum3dptr, computationalLBound=clbvert,&
+                             computationalUBound = cubvert, rc = error)
+             count1vert = cubvert(1)-clbvert(1)+1
+             count2vert = cubvert(2)-clbvert(2)+1 
+             if (allocated(dum3d)) deallocate(dum3d)
+             allocate(dum3d(count1vert, count2vert, nz_input))
+             do i = 1, n_hist_fields_3d_vert
+                call ESMF_FieldGet(fields(i), name=varname, rc=error)
+                if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
+                    call error_handler("IN FieldGet", error)
+                call ESMF_FieldGet(fields(i), farrayPtr=dum3dptr,rc=error)
+                if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
+                    call error_handler("IN FieldGet", error)
+
+                if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID ", trim(varname)
+                 dum3d(:, :, :) = dum3dptr(clbvert(1):cubvert(1),clbvert(2):cubvert(2),:)
+                if (localpet == 0)  print *, trim(varname), minval(dum3d), maxval(dum3d)
+                 error = nf90_put_var(ncid, id_vars3_vert(i), dum3dt, start = (/clbvert(1),clbvert(2),1,1/), &
+                                        count=(/count1vert, count2vert, nz_input, 1/))
+                 call netcdf_err(error, 'WRITING RECORD')
+            end do
         end if
 
         !    3d P fields
-        IF (wrf_mod_vars .AND. localpet == 0) THEN
+        IF (wrf_mod_vars ) THEN
             varname = 'P'
-            print *, "- SET DUMMY VALUES FOR TARGET GRID ", trim(varname)
-
-            dum3d = 0.0
+            if (localpet==0) print *, "- SET DUMMY VALUES FOR TARGET GRID ", trim(varname)
+            if (allocated(dum3d)) deallocate(dum3d)
+            allocate(dum3d(count1, count2, nz_input))
+            dum3d(:,:,:) = 0.0
             !print *, trim(varname), minval(dum3d), maxval(dum3d)
-            dum3dt(:, :, :, 1) = dum3d
-            error = nf90_put_var(ncid, id_dummy3d_p, dum3dt, count=(/i_target, j_target, nz_input, 1/))
+            
+            error = nf90_put_var(ncid, id_dummy3d_p, dum3d, start = (/clb(1),clb(2),1,1/), & 
+                                count=(/count1, count2, nz_input, 1/))
             call netcdf_err(error, 'WRITING RECORD')
         end if
 
-        deallocate (dum3d, dum3dp1, dum3dt, dum3dp1t, dum1d)
-        deallocate (id_vars2, id_vars3_nz, id_vars3_nzp1, id_vars3_vert, id_vars_soil)
-        deallocate (dum2du, dum2dtu, dum2dv, dum2dtv)
-
+        deallocate(dum3d, dum1d)
         if (allocated(target_hist_longname_2d_cons)) deallocate (target_hist_longname_2d_cons)
         if (allocated(target_hist_longname_2d_nstd)) deallocate (target_hist_longname_2d_nstd)
         if (allocated(target_hist_longname_2d_patch)) deallocate (target_hist_longname_2d_patch)

--- a/write_data.F90
+++ b/write_data.F90
@@ -123,7 +123,9 @@ contains
 
         type(esmf_field), allocatable    :: fields(:), field_write_2d(:), field_extra3(:)
         type(timedelta)                 :: xtime_dt
-
+        integer :: clb(2), cub(2)
+        real :: start,finish
+        real(esmf_kind_r8), pointer :: dumptr_3d(:,:,:)
  
         n2d = n_diag_fields + n_hist_fields_2d_patch + n_hist_fields_2d_nstd + n_hist_fields_2d_cons
         allocate (field_write_2d(n2d), id_vars2(n2d))
@@ -167,12 +169,14 @@ contains
             allocate (dum1d(0))
         end if
 
-        if (localpet == 0) then
+       ! if (localpet == 0) then
 
 !--- open the file
-            error = nf90_create(output_file, NF90_NETCDF4, ncid)
+            error = nf90_create(output_file, NF90_NETCDF4, ncid, &
+                                comm = MPI_COMM_WORLD, &
+                                info = MPI_INFO_NULL)
             call netcdf_err(error, 'CREATING FILE '//trim(output_file))
-
+       !if (localpet==0 ) then
 !--- define dimension
             error = nf90_def_dim(ncid, 'Time', NF90_UNLIMITED, dim_time)
             call netcdf_err(error, 'DEFINING Time DIMENSION')
@@ -563,7 +567,8 @@ contains
             error = nf90_put_att(ncid, id_xtime, "MemoryOrder", "O ")
             call netcdf_err(error, 'DEFINING MemoryOrder')
 
-        end if
+        !end if
+
 
         k = 0
         m = 0
@@ -585,7 +590,7 @@ contains
                 if (ndims == 2) then
                     k = k + 1
                     field_write_2d(k) = fields(i)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE 2d diag ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -603,11 +608,11 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 else
                     m = m + 1
                     field_extra3(m) = fields(i)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE 3d diag ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(m))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -625,7 +630,7 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars3_nz(m), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 end if
             end do
             deallocate (fields)
@@ -648,7 +653,7 @@ contains
 
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     field_write_2d(k) = fields(i)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
                         call netcdf_err(error, 'DEFINING VAR')
                         error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
@@ -665,7 +670,7 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
@@ -685,7 +690,7 @@ contains
 
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     field_write_2d(k) = fields(i)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
                         call netcdf_err(error, 'DEFINING VAR')
                         error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
@@ -702,7 +707,7 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
@@ -720,7 +725,7 @@ contains
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
                     field_write_2d(k) = fields(i)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -738,7 +743,7 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars2(k), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
@@ -754,7 +759,7 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_soil, dim_time/), id_vars_soil(i))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -772,7 +777,7 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars_soil(i), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
@@ -789,7 +794,7 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(i + n3d))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -845,11 +850,11 @@ contains
                             error = nf90_put_att(ncid, id_ptop, "_FillValue", missing_value)
                             call netcdf_err(error, 'DEFINING _FillValue')
                         end if
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
-            if (localpet==0) then 
+            !if (localpet==0) then 
             if (do_u_interp==1) then
                print *, "- DEFINE ON FILE STAGGERED TARGET GRID U"
                error = nf90_def_var(ncid, "U", NF90_FLOAT, (/dim_lon_stag, dim_lat, dim_z, dim_time/),id_u)
@@ -889,7 +894,7 @@ contains
                error = nf90_put_att(ncid, id_v, "_FillValue", missing_value)
                call netcdf_err(error, 'DEFINING _FillValue')
             endif
-            endif
+            !endif
 
             if (n_hist_fields_3d_nzp1 > 0) then
                 allocate (fields(n_hist_fields_3d_nzp1))
@@ -902,7 +907,7 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_zp1, dim_time/), id_vars3_nzp1(i))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -946,7 +951,7 @@ contains
                             error = nf90_put_att(ncid, id_ph, "_FillValue", missing_value)
                             call netcdf_err(error, 'DEFINING _FillValue')
                         end if
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
@@ -962,7 +967,7 @@ contains
                     call ESMF_FieldGet(fields(i), name=varname, rc=error)
                     if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                         call error_handler("IN FieldGet", error)
-                    if (localpet == 0) then
+                    !if (localpet == 0) then
                         print *, "- DEFINE ON FILE TARGET GRID ", varname
                         error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_vert(i))
                         call netcdf_err(error, 'DEFINING VAR')
@@ -980,13 +985,13 @@ contains
                         call netcdf_err(error, 'DEFINING FieldType')
                         error = nf90_put_att(ncid, id_vars3_vert(i), "_FillValue", missing_value)
                         call netcdf_err(error, 'DEFINING _FillValue')
-                    end if
+                    !end if
                 end do
                 deallocate (fields)
             end if
         end if !write hist
 
-        IF (wrf_mod_vars .AND. localpet == 0) THEN
+        IF (wrf_mod_vars ) THEN !.AND. localpet == 0) THEN
             ! define dummy 3d fields
             varname = 'P'
             print *, "- DEFINE ON FILE TARGET GRID ", varname
@@ -1025,12 +1030,13 @@ contains
             call netcdf_err(error, 'DEFINING FieldType')
             error = nf90_put_att(ncid, id_dummy3d_pb, "_FillValue", missing_value)
             call netcdf_err(error, 'DEFINING _FillValue')
-        END IF
+         END IF
 
-        if (localpet == 0) then
+        !if (localpet == 0) then
+            print*, "END DEFINE MODE"
             error = nf90_enddef(ncid, header_buffer_val, 4, 0, 4)
             call netcdf_err(error, 'DEFINING HEADER')
-        end if
+        !end if
 
 !--- write fields
 
@@ -1041,35 +1047,35 @@ contains
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
 
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dt(:, :, 1) = dum2d
             error = nf90_put_var(ncid, id_lon, dum2dt, count=(/i_target, j_target, 1/))
             call netcdf_err(error, 'WRITING LONGITUDE RECORD')
-        end if
+        !end if
 
 !  latitude
 
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE"
+        !if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE"
         call ESMF_FieldGather(latitude_target_grid, dum2d, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
 
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dt(:, :, 1) = dum2d
             error = nf90_put_var(ncid, id_lat, dum2dt, count=(/i_target, j_target, 1/))
             call netcdf_err(error, 'WRITING LATITUDE RECORD')
-        end if
+        !end if
 
 !  longitude on u grid
-        if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LONGITUDE U"
+        !if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LONGITUDE U"
         call ESMF_FieldGather(longitude_u_target_grid, dum2du, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dtu(:,:,1) = dum2du
             error = nf90_put_var(ncid, id_lonu, dum2dtu, count=(/i_target+1, j_target, 1/))
             call netcdf_err(error, 'WRITING XLONG_U RECORD')
-        end if
+        !end if
 
 !  latitude on u grid
 
@@ -1077,33 +1083,33 @@ contains
         call ESMF_FieldGather(latitude_u_target_grid, dum2du, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dtu(:,:,1) = dum2du
             error = nf90_put_var(ncid, id_latu, dum2dtu, count=(/i_target+1, j_target, 1/))
             call netcdf_err(error, 'WRITING XLAT_U RECORD')
-        end if
+        !end if
 
 !  latitude on v grid
         if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LATITUDE V"
         call ESMF_FieldGather(latitude_v_target_grid, dum2dv(:, :), rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dtv(:,:,1) = dum2dv
             error = nf90_put_var(ncid, id_latv, dum2dtv, count=(/i_target, j_target+1, 1/))
             call netcdf_err(error, 'WRITING XLAT_V RECORD')
-        end if
+        !end if
 
 !  longitude on v grid
         if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID LONGITUDE V"
         call ESMF_FieldGather(longitude_v_target_grid, dum2dv, rootPet=0, rc=error)
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dtv(:,:,1) = dum2dv
             error = nf90_put_var(ncid, id_lonv, dum2dtv, count=(/i_target, j_target+1, 1/))
             call netcdf_err(error, 'WRITING XLONG_V RECORD')
-        end if
+        !end if
 
 ! mapfac on mass grid
 
@@ -1112,11 +1118,11 @@ contains
         if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
             call error_handler("IN FieldGather", error)
 
-        if (localpet == 0) then
+        !if (localpet == 0) then
             dum2dt(:, :, 1) = dum2d
             error = nf90_put_var(ncid, id_mfm, dum2dt, count=(/i_target, j_target, 1/))
             call netcdf_err(error, 'WRITING MAPFAC_M RECORD')
-        end if
+        !end if
 
 ! mapfac on u grid
 
@@ -1204,8 +1210,11 @@ contains
 
           if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID U"
           if (localpet == 0) then
+              call cpu_time(start)
               error = nf90_put_var(ncid, id_u, dum3dtmp, count=(/i_target + 1, j_target, nz_input, 1/))
               call netcdf_err(error, 'WRITING U RECORD')
+              call cpu_time(finish)
+              print '("Time = ",f6.3," seconds.")',finish-start
           end if
           deallocate(dum3dtmp)
        endif
@@ -1213,20 +1222,30 @@ contains
 !   v
        if (do_v_interp == 1) then
           if (localpet == 0) print *, "- CALL FieldGather FOR TARGET GRID V"
-          if (localpet == 0) then
-            allocate (dum3dtmp(i_target, j_target + 1, nz_input))
-          else
-            allocate (dum3dtmp(0,0,0))
-          endif
-          call ESMF_FieldGather(v_target_grid, dum3dtmp, rootPet=0, rc=error)
+          !if (localpet == 0) then
+          !  allocate (dum3dtmp(i_target, j_target + 1, nz_input))
+          !else
+          !  allocate (dum3dtmp(0,0,0))
+          !endif
+          !call ESMF_FieldGather(v_target_grid, dum3dtmp, rootPet=0, rc=error)
+          !if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
+          !   call error_handler("IN FieldGather", error)
+          call ESMF_FieldGet(v_target_grid, farrayPtr=dumptr_3d, computationalLBound=clb,&
+                             computationalUBound = cub, rc=error)
           if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-             call error_handler("IN FieldGather", error)
-
+             call error_handler("IN FieldGet", error)
+          dum3dtmp(:,:,:) = dumptr_3d(clb(1):cub(1),clb(2):cub(2),:)
+          allocate(dum3dtmp(cub(1)-clb(1)+1, cub(2)-clb(2)+1, nz_input))
           if (localpet == 0) print *, "- WRITE TO FILE TARGET GRID V"
-          if (localpet == 0) then
-              error = nf90_put_var(ncid, id_v, dum3dtmp, count=(/i_target, j_target + 1, nz_input, 1/))
+          if (localpet == 0) call cpu_time(start)
+              ! set to use MPI/PnetCDF collective I/O
+              error =  nf90_var_par_access(ncid, id_v, NF90_COLLECTIVE)
+              call netcdf_err(error ,'SETTING PAR ACCESS ON V')
+              error = nf90_put_var(ncid, id_v, dum3dtmp, start = (/clb(1),clb(2),1,1/),  &
+                                   count=(/cub(1)-clb(1)+1, cub(2)-clb(2)+1, nz_input, 1/))
               call netcdf_err(error, 'WRITING V RECORD')
-          end if
+          if (localpet==0) call cpu_time(finish)
+          if (localpet==0) print '("Time = ",f6.3," seconds.")',finish-start
           deallocate(dum3dtmp)
        endif
 

--- a/write_data.F90
+++ b/write_data.F90
@@ -1378,24 +1378,24 @@ contains
                 call ESMF_FieldGet(fields(n), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGather", error)
-                if (localpet == 0) then
-                        if (wrf_mod_vars .and. trim(varname) == 'T') then
-                            do i = 1, i_target
-                            do j = 1, j_target
-                                if (dum3d(i, j, 1) == missing_value) then
-                                   dum3dt(i,j,:,1) = missing_value
-                                else
-                                   dum3dt(i, j, :, 1) = dum3d(i, j, :) - 300.0
-                                endif
-                            end do
-                            end do
-                        else
-                            dum3dt(:, :, :, 1) = dum3d(:, :, :)
-                        end if
-                        print *, trim(varname), minval(dum3dt), maxval(dum3dt)
-                        error = nf90_put_var(ncid, id_vars3_nz(n + n3d), dum3dt, &
-                                             count=(/i_target, j_target, nz_input, 1/))
-                        call netcdf_err(error, 'WRITING RECORD')
+!                if (localpet == 0) then
+!                        if (wrf_mod_vars .and. trim(varname) == 'T') then
+!                            do i = 1, i_target
+!                            do j = 1, j_target
+!                                if (dum3d(i, j, 1) == missing_value) then
+!                                   dum3dt(i,j,:,1) = missing_value
+!                                else
+!                                   dum3dt(i, j, :, 1) = dum3d(i, j, :) - 300.0
+!                                endif
+!                            end do
+!                            end do
+!                        else
+!                            dum3dt(:, :, :, 1) = dum3d(:, :, :)
+!                        end if
+!                        print *, trim(varname), minval(dum3dt), maxval(dum3dt)
+!                        error = nf90_put_var(ncid, id_vars3_nz(n + n3d), dum3dt, &
+!                                             count=(/i_target, j_target, nz_input, 1/))
+!                        call netcdf_err(error, 'WRITING RECORD')
 
                 if (wrf_mod_vars .and. trim(varname) == 'T') then
                     do i = clb(1),cub(1)

--- a/write_data.F90
+++ b/write_data.F90
@@ -1400,8 +1400,11 @@ contains
                 if (wrf_mod_vars .and. trim(varname) == 'T') then
                     do i = clb(1),cub(1)
                     do j = clb(2),cub(2)
-                        if (dum3dptr(i, j,1) == missing_value) cycle
-                        dum3d(i, j, :) = dum3dptr(i, j, :) - 300.0
+                        if (dum3dptr(i, j,1) == missing_value) then
+                           dum3d(i,j,:) = dum3dptr(i,j,:)
+                        else
+                           dum3d(i, j, :) = dum3dptr(i, j, :) - 300.0
+                        endif
                     end do
                     end do
                 else


### PR DESCRIPTION
This update changes write from being done only on the head process to writing across all processes. Tests suggest a significant speed up (~75%) for large files, such at GSL's hurricane lat-lon grid. 

Note that this update now requires that NetCDF be compiled with HDF5 and the appropriate HDF5 environmental variables / module to be set. 

Addresses #33 