### PR TITLE
Removed duplicated declaration statement in subroutine read_setup_namelist(unum,

### DIFF
--- a/program_setup.F90
+++ b/program_setup.F90
@@ -97,7 +97,6 @@
  integer                                :: is, ie, ierr
  
  !Namelist variables that are used to create global variables
- real                                   :: dx,dy
  integer                                :: nx,ny
 
  namelist /config/ grid_file_input_grid, diag_file_input_grid, hist_file_input_grid, &


### PR DESCRIPTION
This fix just deleted a declaration line in file _program_setup.F90_.

The original declaration of variables `dx`/`dy` hides the corresponding module variables, which prevents the correct values of those variables being written to the output file  when `target_grid_type .ne. “file”`.