### PR TITLE
Bug fixes for GSL MPAS runs

### DIFF
--- a/interp.F90
+++ b/interp.F90
@@ -275,8 +275,8 @@ subroutine fill_missing_field(localpet,in_field,out_field,nd,nx,ny,method, &
         call rotate_winds_cgrid(localpet,2)
      endif
 
-     call fill_missing_bundle(localpet,input_diag_bundle,target_diag_bundle,2,i_target,j_target, &
-                               method,bilinear_regrid,unmapped_ptr_bi)
+     !call fill_missing_bundle(localpet,input_diag_bundle,target_diag_bundle,2,i_target,j_target, &
+     !                          method,bilinear_regrid,unmapped_ptr_bi)
 
   end subroutine interp_diag_data
 

--- a/interp.F90
+++ b/interp.F90
@@ -277,8 +277,8 @@ subroutine fill_missing_field(localpet,in_field,out_field,nd,nx,ny,method, &
         call rotate_winds_cgrid(localpet,2)
      endif
 
-     !call fill_missing_bundle(localpet,input_diag_bundle,target_diag_bundle,2,i_target,j_target, &
-     !                          method,bilinear_regrid,unmapped_ptr_bi)
+     call fill_missing_bundle(localpet,input_diag_bundle,target_diag_bundle,2,i_target,j_target, &
+                               method,bilinear_regrid,unmapped_ptr_bi)
 
   end subroutine interp_diag_data
 

--- a/interp.F90
+++ b/interp.F90
@@ -188,6 +188,18 @@
    do ij = l(1), u(1)
         call ij_to_i_j(unmapped_ptr(ij), nx, ny, i, j)
         do k = 1, num_fields
+           call ESMF_FieldBundleGet(out_bundle,k,field,rc=rc)
+            if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__))&
+              call error_handler("IN FieldBundleGet", rc)
+           call ESMF_FieldGet(field,name=fname,rc=rc)
+            if(ESMF_logFoundError(rcToCheck=rc,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__))&
+              call error_handler("IN FieldGet", rc)
+           if (fname=="REFL_10CM") then
+              ndims = 3
+           else
+              ndims = nd
+           endif
+           if(localpet==0) print*, k, ndims
            if (ndims==2) fptr2(k)%p(i,j) = missing_value
            if (ndims==3) fptr3(k)%p(i,j,:) = missing_value 
         enddo

--- a/model_grid.F90
+++ b/model_grid.F90
@@ -179,7 +179,7 @@
                                           !< with vertical dimension nVertLevelsp1
  integer, public                       :: n_hist_fields_soil
                                           !< number of soil fields read from the hist file
- integer, public                       :: diag_out_interval
+ real, public                          :: diag_out_interval
                                           !< output_interval from diag file
  integer, public                       :: do_u_interp           
                                           !< whether 3d u is requested for interpolation

--- a/write_data.F90
+++ b/write_data.F90
@@ -1324,7 +1324,8 @@ contains
                     call error_handler("IN FieldGet", error)
                 call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGet", error)                
+                    call error_handler("IN FieldGet", error)
+            
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)
                  error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/clb(1),clb(2),1,1/), &

--- a/write_data.F90
+++ b/write_data.F90
@@ -26,7 +26,7 @@ contains
         use program_setup, only: interp_diag, interp_hist, &
                                  wrf_mod_vars, truelat1, truelat2, &
                                  stand_lon, proj_code, map_proj_char, &
-                                 i_target, j_target, dx, &
+                                 i_target, j_target, dxkm, &
                                  ref_lat, ref_lon, pole_lat, &
                                  pole_lon, missing_value
 
@@ -183,10 +183,10 @@ contains
             error = nf90_put_att(ncid, NF90_GLOBAL, 'START_DATE', start_time)
             call netcdf_err(error, 'DEFINING START DATE GLOBAL ATTRIBUTE')
 
-            error = nf90_put_att(ncid, NF90_GLOBAL, 'DX', dx)
+            error = nf90_put_att(ncid, NF90_GLOBAL, 'DX', dxkm)
             call netcdf_err(error, 'DEFINING DX GLOBAL ATTRIBUTE')
 
-            error = nf90_put_att(ncid, NF90_GLOBAL, 'DY', dx)
+            error = nf90_put_att(ncid, NF90_GLOBAL, 'DY', dxkm)
             call netcdf_err(error, 'DEFINING DY GLOBAL ATTRIBUTE')
 
             error = nf90_put_att(ncid, NF90_GLOBAL, 'DT', config_dt)

--- a/write_data.F90
+++ b/write_data.F90
@@ -582,9 +582,11 @@ contains
                 call error_handler("IN FieldBundleGet", error)
             do i = 1, n_diag_fields
                 call ESMF_FieldGet(fields(i), name=varname, rc=error)
+                if (localpet == 0) print *, varname
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
                 call ESMF_FieldGet(fields(i), dimCount=ndims, rc=rc)
+                if (localpet == 0) print *, ndims
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
 
@@ -593,6 +595,13 @@ contains
                     field_write_2d(k) = fields(i)
                      if (localpet == 0) print *, "- DEFINE 2d diag ON FILE TARGET GRID ", varname
                      error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
+                     if (localpet == 0) print *, dim_lon
+                     if (localpet == 0) print *, dim_lat
+                     if (localpet == 0) print *, dim_time
+                     if (localpet == 0) print *, id_vars2(k)
+                     if (localpet == 0) print *, k
+                     if (localpet == 0) print *, target_diag_units(i)
+                     if (localpet == 0) print *, target_diag_longname(i)
                      call netcdf_err(error, 'DEFINING VAR')
                      error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
                      call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -615,6 +624,14 @@ contains
                     field_extra3(m) = fields(i)
                      if (localpet == 0) print *, "- DEFINE 3d diag ON FILE TARGET GRID ", varname
                      error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(m))
+                     if (localpet == 0) print *, dim_lon
+                     if (localpet == 0) print *, dim_lat
+                     if (localpet == 0) print *, dim_z
+                     if (localpet == 0) print *, dim_time
+                     if (localpet == 0) print *, id_vars3_nz(m)
+                     if (localpet == 0) print *, m
+                     if (localpet == 0) print *, target_diag_units(i)
+                     if (localpet == 0) print *, target_diag_longname(i)
                      call netcdf_err(error, 'DEFINING VAR')
                      error = nf90_put_att(ncid, id_vars3_nz(m), "MemoryOrder", "XYZ ")
                      call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -764,6 +781,14 @@ contains
                         call error_handler("IN FieldGet", error)
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_soil, dim_time/), id_vars_soil(i))
+                    if (localpet == 0) print *, dim_lon
+                    if (localpet == 0) print *, dim_lat
+                    if (localpet == 0) print *, dim_soil
+                    if (localpet == 0) print *, dim_time
+                    if (localpet == 0) print *, id_vars_soil(i)
+                    if (localpet == 0) print *, i
+                    if (localpet == 0) print *, target_hist_units_soil(i)
+                    if (localpet == 0) print *, target_hist_longname_soil(i)
                     call netcdf_err(error, 'DEFINING VAR')
                     error = nf90_put_att(ncid, id_vars_soil(i), "MemoryOrder", "XYZ ")
                     call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -799,6 +824,14 @@ contains
                         call error_handler("IN FieldGet", error)
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(i + n3d))
+                     if (localpet == 0) print *, dim_lon
+                     if (localpet == 0) print *, dim_lat
+                     if (localpet == 0) print *, dim_z
+                     if (localpet == 0) print *, dim_time
+                     if (localpet == 0) print *, id_vars3_nz(i+n3d)
+                     if (localpet == 0) print *, i+n3d
+                     if (localpet == 0) print *, target_hist_units_3d_nz(i)
+                     if (localpet == 0) print *, target_hist_longname_3d_nz(i)
                     call netcdf_err(error, 'DEFINING VAR')
                     error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "MemoryOrder", "XYZ ")
                     call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -1317,8 +1350,8 @@ contains
 
         !    3d fields from diaglist
 
-!        if (allocated(dum3d)) deallocate(dum3d)
-!        allocate(dum3d(clb(1):cub(1),clb(2):cub(2),nz_input))
+        if (allocated(dum3d)) deallocate(dum3d)
+        allocate(dum3d(clb(1):cub(1),clb(2):cub(2),nz_input))
         if (n3d > 0) then
             print *, "Loop writing over ", n3d, "3-d nz vars"
             do i = 1, n3d
@@ -1338,7 +1371,7 @@ contains
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 !dum3d(:,:,:) = dum3dptr(1:1799,clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)
-                 error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/1,1,1,1/), &
+                 error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/clb(1),clb(2),1,1/), &
                                 count=(/count1,count2, nz_input, 1/))
                  call netcdf_err(error, 'WRITING RECORD')
             end do

--- a/write_data.F90
+++ b/write_data.F90
@@ -1324,7 +1324,7 @@ contains
                     call error_handler("IN FieldGet", error)
                 call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGet", error)            
+                    call error_handler("IN FieldGet", error)               
 
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)

--- a/write_data.F90
+++ b/write_data.F90
@@ -1324,7 +1324,7 @@ contains
                     call error_handler("IN FieldGet", error)
                 call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGet", error)               
+                    call error_handler("IN FieldGet", error)                
 
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)

--- a/write_data.F90
+++ b/write_data.F90
@@ -1324,8 +1324,8 @@ contains
                     call error_handler("IN FieldGet", error)
                 call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
-                    call error_handler("IN FieldGet", error)
-            
+                    call error_handler("IN FieldGet", error)            
+
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)
                  error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/clb(1),clb(2),1,1/), &

--- a/write_data.F90
+++ b/write_data.F90
@@ -140,6 +140,8 @@ contains
         allocate (dum3d(i_target, j_target, nz_input))
         allocate (dum1d(1))
 
+        if (localpet == 0) print *, "ITARGET,JTARGET,NZINPUT",i_target,j_target,nz_input
+
 !--- open the file
             error = nf90_create_par(output_file, NF90_NETCDF4, &
                                 MPI_COMM_WORLD, &
@@ -1304,6 +1306,7 @@ contains
                 call error_handler("IN FieldGet", error)
 
             if (localpet == 0) print *, "- WRITE TO FILE ", trim(varname)
+            if (localpet == 0) print *,clb(1),cub(1),clb(2),cub(2)
             dum2d(:, :) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
             error = nf90_put_var(ncid, id_vars2(i), dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
@@ -1314,6 +1317,8 @@ contains
 
         !    3d fields from diaglist
 
+!        if (allocated(dum3d)) deallocate(dum3d)
+!        allocate(dum3d(clb(1):cub(1),clb(2):cub(2),nz_input))
         if (n3d > 0) then
             print *, "Loop writing over ", n3d, "3-d nz vars"
             do i = 1, n3d
@@ -1323,10 +1328,17 @@ contains
                 call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)                
-
+            !if (localpet == 0) print *,clb(1),cub(1),clb(2),cub(2)
+            if (localpet == 0) print *,shape(dum3d)
+            if (localpet == 0) print *,shape(dum3dptr)
+            if (localpet == 0) print *,clb(1)
+            if (localpet == 0) print *,cub(1)
+            if (localpet == 0) print *,clb(2)
+            if (localpet == 0) print *,cub(2)
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
+                !dum3d(:,:,:) = dum3dptr(1:1799,clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)
-                 error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/clb(1),clb(2),1,1/), &
+                 error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/1,1,1,1/), &
                                 count=(/count1,count2, nz_input, 1/))
                  call netcdf_err(error, 'WRITING RECORD')
             end do
@@ -1408,6 +1420,13 @@ contains
                     end do
                     end do
                 else
+                   !if (localpet == 0) print *,clb(1),cub(1),clb(2),cub(2)
+                   if (localpet == 0) print *,shape(dum3d)
+                   if (localpet == 0) print *,shape(dum3dptr)
+                   if (localpet == 0) print *,clb(1)
+                   if (localpet == 0) print *,cub(1)
+                   if (localpet == 0) print *,clb(2)
+                   if (localpet == 0) print *,cub(2)
                    dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 end if
                 if (localpet==0) print *, trim(varname), minval(dum3d), maxval(dum3d)

--- a/write_data.F90
+++ b/write_data.F90
@@ -140,8 +140,6 @@ contains
         allocate (dum3d(i_target, j_target, nz_input))
         allocate (dum1d(1))
 
-        if (localpet == 0) print *, "ITARGET,JTARGET,NZINPUT",i_target,j_target,nz_input
-
 !--- open the file
             error = nf90_create_par(output_file, NF90_NETCDF4, &
                                 MPI_COMM_WORLD, &
@@ -582,11 +580,9 @@ contains
                 call error_handler("IN FieldBundleGet", error)
             do i = 1, n_diag_fields
                 call ESMF_FieldGet(fields(i), name=varname, rc=error)
-                if (localpet == 0) print *, varname
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
                 call ESMF_FieldGet(fields(i), dimCount=ndims, rc=rc)
-                if (localpet == 0) print *, ndims
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)
 
@@ -595,13 +591,6 @@ contains
                     field_write_2d(k) = fields(i)
                      if (localpet == 0) print *, "- DEFINE 2d diag ON FILE TARGET GRID ", varname
                      error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_time/), id_vars2(k))
-                     if (localpet == 0) print *, dim_lon
-                     if (localpet == 0) print *, dim_lat
-                     if (localpet == 0) print *, dim_time
-                     if (localpet == 0) print *, id_vars2(k)
-                     if (localpet == 0) print *, k
-                     if (localpet == 0) print *, target_diag_units(i)
-                     if (localpet == 0) print *, target_diag_longname(i)
                      call netcdf_err(error, 'DEFINING VAR')
                      error = nf90_put_att(ncid, id_vars2(k), "MemoryOrder", "XY ")
                      call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -624,14 +613,6 @@ contains
                     field_extra3(m) = fields(i)
                      if (localpet == 0) print *, "- DEFINE 3d diag ON FILE TARGET GRID ", varname
                      error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(m))
-                     if (localpet == 0) print *, dim_lon
-                     if (localpet == 0) print *, dim_lat
-                     if (localpet == 0) print *, dim_z
-                     if (localpet == 0) print *, dim_time
-                     if (localpet == 0) print *, id_vars3_nz(m)
-                     if (localpet == 0) print *, m
-                     if (localpet == 0) print *, target_diag_units(i)
-                     if (localpet == 0) print *, target_diag_longname(i)
                      call netcdf_err(error, 'DEFINING VAR')
                      error = nf90_put_att(ncid, id_vars3_nz(m), "MemoryOrder", "XYZ ")
                      call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -781,14 +762,6 @@ contains
                         call error_handler("IN FieldGet", error)
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_soil, dim_time/), id_vars_soil(i))
-                    if (localpet == 0) print *, dim_lon
-                    if (localpet == 0) print *, dim_lat
-                    if (localpet == 0) print *, dim_soil
-                    if (localpet == 0) print *, dim_time
-                    if (localpet == 0) print *, id_vars_soil(i)
-                    if (localpet == 0) print *, i
-                    if (localpet == 0) print *, target_hist_units_soil(i)
-                    if (localpet == 0) print *, target_hist_longname_soil(i)
                     call netcdf_err(error, 'DEFINING VAR')
                     error = nf90_put_att(ncid, id_vars_soil(i), "MemoryOrder", "XYZ ")
                     call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -824,14 +797,6 @@ contains
                         call error_handler("IN FieldGet", error)
                     if (localpet == 0) print *, "- DEFINE ON FILE TARGET GRID ", varname
                     error = nf90_def_var(ncid, varname, NF90_FLOAT, (/dim_lon, dim_lat, dim_z, dim_time/), id_vars3_nz(i + n3d))
-                     if (localpet == 0) print *, dim_lon
-                     if (localpet == 0) print *, dim_lat
-                     if (localpet == 0) print *, dim_z
-                     if (localpet == 0) print *, dim_time
-                     if (localpet == 0) print *, id_vars3_nz(i+n3d)
-                     if (localpet == 0) print *, i+n3d
-                     if (localpet == 0) print *, target_hist_units_3d_nz(i)
-                     if (localpet == 0) print *, target_hist_longname_3d_nz(i)
                     call netcdf_err(error, 'DEFINING VAR')
                     error = nf90_put_att(ncid, id_vars3_nz(i + n3d), "MemoryOrder", "XYZ ")
                     call netcdf_err(error, 'DEFINING MEMORYORDER')
@@ -1339,7 +1304,6 @@ contains
                 call error_handler("IN FieldGet", error)
 
             if (localpet == 0) print *, "- WRITE TO FILE ", trim(varname)
-            if (localpet == 0) print *,clb(1),cub(1),clb(2),cub(2)
             dum2d(:, :) = dum2dptr(clb(1):cub(1),clb(2):cub(2))
             error = nf90_put_var(ncid, id_vars2(i), dum2d, start = (/clb(1),clb(2),1/),  &
                                    count=(/count1, count2, 1/))
@@ -1361,15 +1325,7 @@ contains
                 call ESMF_FieldGet(field_extra3(i), farrayPtr = dum3dptr, rc=error)
                 if (ESMF_logFoundError(rcToCheck=error, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) &
                     call error_handler("IN FieldGet", error)                
-            !if (localpet == 0) print *,clb(1),cub(1),clb(2),cub(2)
-            if (localpet == 0) print *,shape(dum3d)
-            if (localpet == 0) print *,shape(dum3dptr)
-            if (localpet == 0) print *,clb(1)
-            if (localpet == 0) print *,cub(1)
-            if (localpet == 0) print *,clb(2)
-            if (localpet == 0) print *,cub(2)
                 dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
-                !dum3d(:,:,:) = dum3dptr(1:1799,clb(2):cub(2),:)
                 if (localpet == 0) print *, trim(varname), minval(dum3d), maxval(dum3d)
                  error = nf90_put_var(ncid, id_vars3_nz(i), dum3d, start = (/clb(1),clb(2),1,1/), &
                                 count=(/count1,count2, nz_input, 1/))
@@ -1453,13 +1409,6 @@ contains
                     end do
                     end do
                 else
-                   !if (localpet == 0) print *,clb(1),cub(1),clb(2),cub(2)
-                   if (localpet == 0) print *,shape(dum3d)
-                   if (localpet == 0) print *,shape(dum3dptr)
-                   if (localpet == 0) print *,clb(1)
-                   if (localpet == 0) print *,cub(1)
-                   if (localpet == 0) print *,clb(2)
-                   if (localpet == 0) print *,cub(2)
                    dum3d(:,:,:) = dum3dptr(clb(1):cub(1),clb(2):cub(2),:)
                 end if
                 if (localpet==0) print *, trim(varname), minval(dum3d), maxval(dum3d)


### PR DESCRIPTION
This PR solves several problems seen in GSL MPAS runs:

(1) PREC_ACC_DT needs to be a real instead of integer (in order to be read in correctly by UPP)

(2) Issue reported in issue #41 

(3) dx needs to be changed to dxkm in write_data.F90

The code has been tested for GSL's realtime 3km "HRRRv5" MPAS configuration, as well as the realtime 1km MPAS fire weather configuration.

